### PR TITLE
Fixes a couple of small issues

### DIFF
--- a/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
@@ -63,6 +63,8 @@ class JMHPlugin implements Plugin<Project> {
             manifest {
                 attributes 'Main-Class': 'org.openjdk.jmh.Main'
             }
+
+            classifier = 'jmh'
         }
         project.tasks.create(name: 'jmh', type: JavaExec) {
             dependsOn project.jmhJar


### PR DESCRIPTION
1. The `jmh` classifier is added to generated jars for clarity.
2. The dependencies from the `main` configuration are automatically added as dependencies of `jmh`
3. The generated classes of the `main` configuration are packed inside the jmh jar
