### PR TITLE
jmhJar should not be up-to-date when jmsClasses change

### DIFF
--- a/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
@@ -52,6 +52,7 @@ class JMHPlugin implements Plugin<Project> {
 
         project.tasks.create(name: 'jmhJar', type: Jar) {
             dependsOn 'jmhClasses'
+            inputs.dir project.sourceSets.jmh.output
             doFirst {
                 from(project.configurations.jmh.collect { it.isDirectory() ? it : project.zipTree(it) }) {
                     exclude '**/META-INF/services/**'


### PR DESCRIPTION
Fix for https://github.com/melix/jmh-gradle-plugin/issues/10.
I think Gradle wasn't picking up the changes because the _from_ configs are specified in a _doFirst_ closure. This fix puts a specific inputs.dir on the output of the jmh sourceset.
