### PR TITLE
jmhJar should not be up-to-date when main classes change

### DIFF
--- a/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
@@ -53,6 +53,7 @@ class JMHPlugin implements Plugin<Project> {
         project.tasks.create(name: 'jmhJar', type: Jar) {
             dependsOn 'jmhClasses'
             inputs.dir project.sourceSets.jmh.output
+            inputs.dir project.sourceSets.main.output
             doFirst {
                 from(project.configurations.jmh.collect { it.isDirectory() ? it : project.zipTree(it) }) {
                     exclude '**/META-INF/services/**'


### PR DESCRIPTION
Also needed a inputs.dir in jmhJar task for project.sourceSets.main.output, so jmhJar is executed if subject classes under benchmark tests change. Related to issue #10.