### PR TITLE
Sets the runtimeClasspath first then the generated MyApp-jmh.jar. 

### DIFF
--- a/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
@@ -77,7 +77,7 @@ class JMHPlugin implements Plugin<Project> {
             classpath = project.files {project.jmhJar.archivePath}
 
             doFirst {
-                classpath += project.sourceSets.main.runtimeClasspath
+                classpath = project.sourceSets.main.runtimeClasspath + classpath
                 args = [*args, *extension.buildArgs()]
                 extension.humanOutputFile?.parentFile?.mkdirs()
                 extension.resultsFile?.parentFile?.mkdirs()


### PR DESCRIPTION
Hi guys, 

I have some classpath ordering issues when I;m trying to execute a benchmark for a large (about +200 MB of .jar dependencies) application. Regarding http://docs.oracle.com/javase/7/docs/technotes/tools/findingclasses.html the overwriting order is "undefined" but at least on linux//jdk8-x86 to define the classpath like "runtimeclasspath + MyApp-jmh.jar" solved the problem. Any other ideas are welcome. 

Thank you. 

Cheers, 
Jiri
