### PR TITLE
Pull request for fixing issue 26: jmh.jmhVersion definition does not work properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+build
+.gradle
+.idea
+*.iml
+*.ipr
+*.iws
+

--- a/README.adoc
+++ b/README.adoc
@@ -57,13 +57,14 @@ jmh {
     jmhVersion = '1.3.2'
 }
 
+----
+
 The jars
 
 * `org.openjdk.jmh:jmh-core`
 * `org.openjdk.jmh:jmh-generator-annprocess`
 
 will be automatically added to the list of library dependencies for the jmh configuration.
-----
 
 == Tasks
 

--- a/README.adoc
+++ b/README.adoc
@@ -8,6 +8,28 @@ This plugin integrates the http://openjdk.java.net/projects/code-tools/jmh/[JMH 
 - Fixed sourceSet definitions being attached to idea root project only instead of the actual module
 - Provides a small sample module as show case (Run gradle jmh in sample subdirectory)
 
+**In order to use this fork, please build and ship it to you local maven repository with**
+[source,bash]
+----
+gradle publishToMavenLocal
+----
+
+**Then use this alternative buildscript block**
+[source,groovy]
+.build.gradle
+----
+buildscript {
+   repositories {
+      mavenLocal()
+   }
+   dependencies {
+      classpath 'me.champeau.gradle:jmh-gradle-plugin:+'
+   }
+}
+----
+
+We will try to get this integrated back to the master. A re-release of the fork is also considered in future.
+
 == Original Readme Start
 == Usage
 

--- a/README.adoc
+++ b/README.adoc
@@ -56,6 +56,13 @@ The plugin uses JMH '1.3.2'. You can change JMH version in the `jmh` block:
 jmh {
     jmhVersion = '1.3.2'
 }
+
+The jars
+
+* `org.openjdk.jmh:jmh-core`
+* `org.openjdk.jmh:jmh-generator-annprocess`
+
+will be automatically added to the list of library dependencies for the jmh configuration.
 ----
 
 == Tasks
@@ -114,7 +121,7 @@ jmh {
    warmupBenchmarks = ['.*Warmup'] // Warmup benchmarks to include in the run in addition to already selected. JMH will not measure these benchmarks, but only use them for the warmup.
 
    zip64 = true // Use ZIP64 format for bigger archives
-   jmhVersion = 1.3.2 // Specifies JMH version
+   jmhVersion = '1.3.2' // Specifies JMH version
    includeTests = false // Allows to include test sources into generate JMH jar, i.e. use it when benchmarks depend on the test classes.
 }
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -2,6 +2,13 @@
 
 This plugin integrates the http://openjdk.java.net/projects/code-tools/jmh/[JMH micro-benchmarking framework] with Gradle.
 
+== Fork adaptions/changes
+- Adapted to work wih gradle 2.2.1
+- Fixed JMH version definition ignored issue (https://github.com/melix/jmh-gradle-plugin/issues/26)
+- Fixed sourceSet definitions being attached to idea root project only instead of the actual module
+- Provides a small sample module as show case (Run gradle jmh in sample subdirectory)
+
+== Original Readme Start
 == Usage
 
 To enable the plugin, you must add this to your `build.gradle` file:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -16,4 +16,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-bin.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -12,6 +12,7 @@ buildscript {
 }
 
 apply plugin: 'java'
+apply plugin: 'idea'
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'me.champeau.gradle.jmh'
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,0 +1,38 @@
+buildscript {
+    repositories {
+        mavenLocal()
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.0'
+        classpath 'me.champeau.gradle:jmh-gradle-plugin:+'
+    }
+
+}
+
+apply plugin: 'java'
+apply plugin: 'com.github.johnrengelman.shadow'
+apply plugin: 'me.champeau.gradle.jmh'
+
+
+group = 'me.champeau.gradle.jmh'
+version = '0.1-SNAPSHOT'
+
+jmh {
+    jmhVersion =  '1.3.3' // Specifies JMH version
+}
+
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
+compileJava.options.encoding = 'UTF-8'
+compileTestJava.options.encoding = 'UTF-8'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testCompile 'junit:junit:4.11'
+}

--- a/sample/src/jmh/java/me/champeau/gradle/jmh/sample/SampleBenchmark.java
+++ b/sample/src/jmh/java/me/champeau/gradle/jmh/sample/SampleBenchmark.java
@@ -1,0 +1,11 @@
+package me.champeau.gradle.jmh.sample;
+
+import org.openjdk.jmh.annotations.Benchmark;
+
+public class SampleBenchmark {
+
+    @Benchmark
+    public void sqrtBenchmark(){
+        Math.sqrt(3.0);
+    }
+}

--- a/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
@@ -138,11 +138,10 @@ class JMHPlugin implements Plugin<Project> {
                         scopes.TEST.plus += [project.configurations.jmh]
                     }
                 }
-                def rootProject = project.rootProject
-                rootProject.idea {
+                project.idea {
                     module {
                         project.sourceSets.jmh.java.srcDirs.each {
-                            testSourceDirs += rootProject.file(it)
+                            testSourceDirs += project.file(it)
                         }
                     }
                 }

--- a/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
@@ -29,6 +29,9 @@ import org.gradle.api.tasks.bundling.Jar
  */
 class JMHPlugin implements Plugin<Project> {
 
+    public static final String JMH_CORE_DEPENDENCY = 'org.openjdk.jmh:jmh-core:'
+    public static final String JMH_ANNOT_PROC_DEPENDENCY = 'org.openjdk.jmh:jmh-generator-annprocess:'
+
     void apply(Project project) {
         project.plugins.apply(JavaPlugin)
         final JMHPluginExtension extension = project.extensions.create('jmh', JMHPluginExtension, project)
@@ -50,8 +53,8 @@ class JMHPlugin implements Plugin<Project> {
             public void execute(ResolvableDependencies resolvableDependencies) {
                 DependencyHandler dependencyHandler = project.getDependencies();
                 def dependencies = configuration.getDependencies()
-                dependencies.add(dependencyHandler.create("org.openjdk.jmh:jmh-core:" + extension.jmhVersion))
-                dependencies.add(dependencyHandler.create("org.openjdk.jmh:jmh-generator-annprocess:" + extension.jmhVersion))
+                dependencies.add(dependencyHandler.create(JMH_CORE_DEPENDENCY + extension.jmhVersion))
+                dependencies.add(dependencyHandler.create(JMH_ANNOT_PROC_DEPENDENCY + extension.jmhVersion))
             }
         });
 


### PR DESCRIPTION
Hereby I propose a fix for correctly setting up jmh dependencies according to the jmhVersion defined.
Contained changes:
- Raised gradle version to latest 2.2.1
- Added beforeResolve action, which contributes the jmh dependencies
- Added unit test
- Added small sample module to proof functionality and give a starting point for users.

Cheers
Ben