### PR TITLE
Let JMH go to the console by default

### DIFF
--- a/src/main/groovy/me/champeau/gradle/JMHPluginExtension.java
+++ b/src/main/groovy/me/champeau/gradle/JMHPluginExtension.java
@@ -51,7 +51,6 @@ public class JMHPluginExtension {
 
     public JMHPluginExtension(final Project project) {
         this.project = project;
-        this.humanOutputFile = project.file(String.valueOf(project.getBuildDir()) + "/reports/jmh/human.txt");
         this.resultsFile = project.file(String.valueOf(project.getBuildDir()) + "/reports/jmh/results.txt");
     }
 


### PR DESCRIPTION
Fix for #17, i.e. do not set ```humanOutputFile``` property by default.

From @hackergarten at Basel. 