### PR TITLE
Apply same set of META-INF excludes in all cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ build
 *.iml
 *.ipr
 *.iws
-
+out


### PR DESCRIPTION
This PR cleans up `META-INF` excludes processing as commented in #38, i.e. it applies same excludes in both cases with and without shadow.