### PR TITLE
Add ability for benchmarkMode to have multiple modes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -86,7 +86,7 @@ jmh {
    include = 'some regular expression' // include pattern (regular expression) for benchmarks to be executed
    exclude = 'some regular expression' // exclude pattern (regular expression) for benchmarks to be executed
    iterations = 10 // Number of measurement iterations to do.
-   benchmarkMode = 'thrpt' // Benchmark mode. Available modes are: [Throughput/thrpt, AverageTime/avgt, SampleTime/sample, SingleShotTime/ss, All/all]
+   benchmarkMode = ['thrpt','ss'] // Benchmark mode. Available modes are: [Throughput/thrpt, AverageTime/avgt, SampleTime/sample, SingleShotTime/ss, All/all]
    batchSize = 1 // Batch size: number of benchmark method calls per operation. (some benchmark modes can ignore this setting)
    fork = 2 // How many times to forks a single benchmark. Use 0 to disable forking altogether
    failOnError = false // Should JMH fail immediately if any benchmark had experienced the unrecoverable error?

--- a/src/funcTest/resources/java-project/build.gradle
+++ b/src/funcTest/resources/java-project/build.gradle
@@ -9,5 +9,6 @@ repositories {
 
 jmh {
     resultFormat = 'csv'
+    benchmarkMode = ['thrpt', 'ss']
     resultsFile = file('build/reports/benchmarks.csv')
 }

--- a/src/main/groovy/me/champeau/gradle/JMHPluginExtension.java
+++ b/src/main/groovy/me/champeau/gradle/JMHPluginExtension.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class JMHPluginExtension {
     private final Project project;
@@ -30,7 +31,7 @@ public class JMHPluginExtension {
 
     private String include = "";
     private String exclude;
-    private String benchmarkMode;
+    private Set<String> benchmarkMode;
     private Integer iterations;
     private Integer batchSize;
     private Integer fork;
@@ -73,7 +74,7 @@ public class JMHPluginExtension {
         args.add(include);
         addOption(args, exclude, "e");
         addOption(args, iterations, "i");
-        addOption(args, benchmarkMode, "bm");
+        addOption(args, asList(benchmarkMode), "bm");
         addOption(args, batchSize, "bs");
         addOption(args, fork, "f");
         addOption(args, failOnError, "foe");
@@ -190,6 +191,11 @@ public class JMHPluginExtension {
             options.add(sb.toString());
         }
     }
+
+    private List<String> asList(Set<String> set) {
+        return set != null ? new ArrayList<String>(set) : null;
+    }
+
     public String getInclude() {
         return include;
     }
@@ -206,11 +212,11 @@ public class JMHPluginExtension {
         this.exclude = exclude;
     }
 
-    public String getBenchmarkMode() {
+    public Set<String> getBenchmarkMode() {
         return benchmarkMode;
     }
 
-    public void setBenchmarkMode(String benchmarkMode) {
+    public void setBenchmarkMode(Set<String> benchmarkMode) {
         this.benchmarkMode = benchmarkMode;
     }
 


### PR DESCRIPTION
Modify config to allow the following:

*Before*

```java
jmh{
    benchmarkMode = 'thrpt'
    ....
}
```

*After*

```java

jmh{
    benchmarkMode = ['thrpt', 'ss']
    ....
}
```