### PR TITLE
Remove unused method

### DIFF
--- a/src/main/groovy/me/champeau/gradle/JMHPluginExtension.java
+++ b/src/main/groovy/me/champeau/gradle/JMHPluginExtension.java
@@ -194,10 +194,6 @@ public class JMHPluginExtension {
         }
     }
 
-    private List<String> asList(Set<String> set) {
-        return set != null ? new ArrayList<String>(set) : null;
-    }
-
     public String getInclude() {
         return include;
     }


### PR DESCRIPTION
In commit be055bce658f38a6b7712d835fe4a3b98a54cbfb @aalmiray "Use List instead of Set when defining benchmarkMode values" left `asList(...)` lingering so removing dead code.