### PR TITLE
Restore publishRelease task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,3 +85,5 @@ jacocoTestReport {
         html.enabled = true
     }
 }
+
+task publishRelease(dependsOn: [bintrayUpload, publishPlugins]) {}


### PR DESCRIPTION
This PR restores `publishRelease` task was added by https://github.com/melix/jmh-gradle-plugin/commit/85443876727fc7d1dd876fd7ad3af7321e260643 commit and lost during merge of PR #74 (see https://github.com/melix/jmh-gradle-plugin/commit/cfc1c9d0161b0ad500b17c6e604224a3e0fe4094).
