### PR TITLE
Feature/update default jmh version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 = JMH Gradle Plugin
-:jmh-version: 1.19
+:jmh-version: 1.20
 :plugin-version: 0.4.5
 
 image:http://img.shields.io/travis/melix/jmh-gradle-plugin/master.svg["Build Status (travis)", link="https://travis-ci.org/melix/jmh-gradle-plugin"]

--- a/build.gradle
+++ b/build.gradle
@@ -15,15 +15,15 @@
  */
 
 plugins {
-    id 'com.gradle.build-scan' version '1.10'
-    id 'me.champeau.buildscan-recipes' version '0.2.0'
-    id 'com.jfrog.bintray' version '1.7.3'
-    id 'com.jfrog.artifactory' version '4.4.12'
-    id 'com.github.hierynomus.license' version '0.11.0'
-    id 'net.nemerosa.versioning' version '2.6.0'
-    id 'com.github.ben-manes.versions' version '0.13.0'
-    id 'com.gradle.plugin-publish' version '0.9.7'
-    id 'com.github.kt3k.coveralls' version '2.7.1'
+    id 'com.gradle.build-scan' version '1.11'
+    id 'me.champeau.buildscan-recipes' version '0.2.3'
+    id 'com.jfrog.bintray' version '1.8.0'
+    id 'com.jfrog.artifactory' version '4.6.0'
+    id 'com.github.hierynomus.license' version '0.14.0'
+    id 'net.nemerosa.versioning' version '2.6.1'
+    id 'com.github.ben-manes.versions' version '0.17.0'
+    id 'com.gradle.plugin-publish' version '0.9.9'
+    id 'com.github.kt3k.coveralls' version '2.8.2'
     id 'jacoco'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,6 @@ project_vcs=https://github.com/melix/jmh-gradle-plugin.git
 
 jacocoVersion      = 0.7.7.201606060606
 jmhVersion         = 1.19
-shadowVersion      = 2.0.1
+shadowVersion      = 2.0.2
 junitVersion       = 4.12
-spockVersion       = 1.0-groovy-2.4
+spockVersion       = 1.1-groovy-2.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ project_issues=https://github.com/melix/jmh-gradle-plugin/issues
 project_vcs=https://github.com/melix/jmh-gradle-plugin.git
 
 jacocoVersion      = 0.7.7.201606060606
-jmhVersion         = 1.19
+jmhVersion         = 1.20
 shadowVersion      = 2.0.2
 junitVersion       = 4.12
 spockVersion       = 1.1-groovy-2.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3-rc-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-bin.zip

--- a/src/funcTest/resources/kotlin-project/build.gradle
+++ b/src/funcTest/resources/kotlin-project/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.0.1'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.0'
     }
 }
 
@@ -33,7 +33,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib:1.0.1'
+    compile 'org.jetbrains.kotlin:kotlin-stdlib:1.2.0'
 }
 
 jmh {

--- a/src/main/groovy/me/champeau/gradle/JMHPluginExtension.java
+++ b/src/main/groovy/me/champeau/gradle/JMHPluginExtension.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class JMHPluginExtension {
     private final Project project;
 
-    private String jmhVersion = "1.17.4";
+    private String jmhVersion = "1.19";
     private final Property<Boolean> includeTestState;
 
     private List<String> include = new ArrayList<String>();

--- a/src/main/groovy/me/champeau/gradle/JMHPluginExtension.java
+++ b/src/main/groovy/me/champeau/gradle/JMHPluginExtension.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class JMHPluginExtension {
     private final Project project;
 
-    private String jmhVersion = "1.19";
+    private String jmhVersion = "1.20";
     private final Property<Boolean> includeTestState;
 
     private List<String> include = new ArrayList<String>();


### PR DESCRIPTION
Several items:
1. Update dependent components to newer version (gradle runner inclusive)
2. Use full gradle distribution (to see more hints in IntelliJ Idea)
3. Update default version of JMH as 1.19 (as written in documentation)