### PR TITLE
Ensure that resources are copied last to JAR

### DIFF
--- a/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
@@ -208,8 +208,8 @@ class JMHPlugin implements Plugin<Project> {
         }
         shadow.from(project.sourceSets.jmh.output)
         shadow.from(project.sourceSets.main.output)
-        shadow.from(project.file(jmhGeneratedResourcesDir))
         shadow.from(project.file(jmhGeneratedClassesDir))
+        shadow.from(project.file(jmhGeneratedResourcesDir))
 
         shadow.exclude(metaInfExcludes)
         shadow.configurations = []
@@ -226,8 +226,8 @@ class JMHPlugin implements Plugin<Project> {
             doFirst {
                 from(project.sourceSets.jmh.output)
                 from(project.sourceSets.main.output)
-                from(project.file(jmhGeneratedResourcesDir))
                 from(project.file(jmhGeneratedClassesDir))
+                from(project.file(jmhGeneratedResourcesDir))
                 if (extension.includeTests) {
                     from(project.sourceSets.test.output)
                 }


### PR DESCRIPTION
@melix This PR addresses [an issue with a blank BenchmarkList file](https://github.com/melix/jmh-gradle-plugin/issues/130) due to the fact that the generated classes directory includes a blank BenchmarkList file and is winning out over the populated one in the generated resources directory.  The PR re-organizes the order of the copy commands for the Gradle JAR task to ensure that the resources directory is copied last (and therefore the populated BenchmarkList is included).