### PR TITLE
fixed shadow function tests

### DIFF
--- a/src/funcTest/groovy/me/champeau/gradle/JmhWithShadowPluginSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/gradle/JmhWithShadowPluginSpec.groovy
@@ -26,12 +26,12 @@ import spock.lang.Unroll
 class JmhWithShadowPluginSpec extends Specification {
     def "Run #language benchmarks that are packaged with Shadow plugin"() {
         given:
-        File projectDir = new File("src/funcTest/resources/${language.toLowerCase()}-project")
-        def pluginClasspathResource = getClass().classLoader.findResource("plugin-classpath.txt")
+        File projectDir = new File("src/funcTest/resources/${language.toLowerCase()}-shadow-project")
+        def pluginClasspathResource = getClass().classLoader.getResourceAsStream("plugin-classpath.txt")
         if (pluginClasspathResource == null) {
             throw new IllegalStateException("Did not find plugin classpath resource, run `testClasses` build task.")
         }
-        List<String> pluginClasspath = pluginClasspathResource.readLines().collect { new File(it) }
+        List<File> pluginClasspath = pluginClasspathResource.readLines().collect { new File(it) }
 
         BuildResult project = GradleRunner.create()
             .withProjectDir(projectDir)

--- a/src/funcTest/groovy/me/champeau/gradle/MultiLanguageSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/gradle/MultiLanguageSpec.groovy
@@ -27,11 +27,11 @@ class MultiLanguageSpec extends Specification {
     def "Execute #language benchmarks"() {
         given:
         File projectDir = new File("src/funcTest/resources/${language.toLowerCase()}-project")
-        def pluginClasspathResource = getClass().classLoader.findResource("plugin-classpath.txt")
+        def pluginClasspathResource = getClass().classLoader.getResourceAsStream("plugin-classpath.txt")
         if (pluginClasspathResource == null) {
             throw new IllegalStateException("Did not find plugin classpath resource, run `testClasses` build task.")
         }
-        List<String> pluginClasspath = pluginClasspathResource.readLines().collect { new File(it) }
+        List<File> pluginClasspath = pluginClasspathResource.readLines().collect { new File(it) }
 
         BuildResult project = GradleRunner.create()
             .withProjectDir(projectDir)

--- a/src/funcTest/groovy/me/champeau/gradle/MultiProjectLanguageSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/gradle/MultiProjectLanguageSpec.groovy
@@ -27,11 +27,11 @@ class MultiProjectLanguageSpec extends Specification {
     def "Should not execute JMH tests from different projects concurrently"() {
         given:
         File projectDir = new File("src/funcTest/resources/java-multi-project")
-        def pluginClasspathResource = getClass().classLoader.findResource("plugin-classpath.txt")
+        def pluginClasspathResource = getClass().classLoader.getResourceAsStream("plugin-classpath.txt")
         if (pluginClasspathResource == null) {
             throw new IllegalStateException("Did not find plugin classpath resource, run `testClasses` build task.")
         }
-        List<String> pluginClasspath = pluginClasspathResource.readLines().collect { new File(it) }
+        List<File> pluginClasspath = pluginClasspathResource.readLines().collect { new File(it) }
 
         BuildResult project = GradleRunner.create()
             .withProjectDir(projectDir)

--- a/src/funcTest/groovy/me/champeau/gradle/ProjectWithDuplicateClassesSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/gradle/ProjectWithDuplicateClassesSpec.groovy
@@ -30,7 +30,7 @@ class ProjectWithDuplicateClassesSpec extends Specification {
         projectDir = new File("src/funcTest/resources/java-project-with-duplicate-classes")
         buildFile = new File(projectDir, 'build.gradle')
         assert buildFile.createNewFile()
-        def pluginClasspathResource = getClass().classLoader.findResource("plugin-classpath.txt")
+        def pluginClasspathResource = getClass().classLoader.getResourceAsStream("plugin-classpath.txt")
         if (pluginClasspathResource == null) {
             throw new IllegalStateException("Did not find plugin classpath resource, run `testClasses` build task.")
         }

--- a/src/funcTest/groovy/me/champeau/gradle/ProjectWithDuplicateDependenciesSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/gradle/ProjectWithDuplicateDependenciesSpec.groovy
@@ -30,7 +30,7 @@ class ProjectWithDuplicateDependenciesSpec extends Specification {
         projectDir = new File("src/funcTest/resources/java-project-with-duplicate-dependencies")
         buildFile = new File(projectDir, 'build.gradle')
         assert buildFile.createNewFile()
-        def pluginClasspathResource = getClass().classLoader.findResource("plugin-classpath.txt")
+        def pluginClasspathResource = getClass().classLoader.getResourceAsStream("plugin-classpath.txt")
         if (pluginClasspathResource == null) {
             throw new IllegalStateException("Did not find plugin classpath resource, run `testClasses` build task.")
         }

--- a/src/funcTest/groovy/me/champeau/gradle/ProjectWithTestDependenciesSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/gradle/ProjectWithTestDependenciesSpec.groovy
@@ -25,11 +25,11 @@ class ProjectWithTestDependenciesSpec extends Specification {
     def "Run project with dependencies on test sources"() {
         given:
         File projectDir = new File("src/funcTest/resources/java-project-with-test-dependencies")
-        def pluginClasspathResource = getClass().classLoader.findResource("plugin-classpath.txt")
+        def pluginClasspathResource = getClass().classLoader.getResourceAsStream("plugin-classpath.txt")
         if (pluginClasspathResource == null) {
             throw new IllegalStateException("Did not find plugin classpath resource, run `testClasses` build task.")
         }
-        List<String> pluginClasspath = pluginClasspathResource.readLines().collect { new File(it) }
+        List<File> pluginClasspath = pluginClasspathResource.readLines().collect { new File(it) }
 
         BuildResult project = GradleRunner.create()
             .withProjectDir(projectDir)


### PR DESCRIPTION
Few small fixes of functional tests. I noticed that some quite time ago shadow func test was probably incidently rewritten to use projects without shadow plugin.
I've also changed the protected groovy `findResource` method to the public `getResourceAsStream` one.