### PR TITLE
fix: run GC after Runner finished

### DIFF
--- a/src/main/groovy/me/champeau/gradle/IsolatedRunner.java
+++ b/src/main/groovy/me/champeau/gradle/IsolatedRunner.java
@@ -38,6 +38,8 @@ public class IsolatedRunner implements Runnable {
             runner.run();
         } catch (RunnerException e) {
             throw new GradleException("Error during execution of benchmarks", e);
+        } finally {
+            runner.runSystemGC();
         }
     }
 }


### PR DESCRIPTION
This patch, used together with `forceGC=true`, fixes #134.