### PR TITLE
POC to add parameters to JMHTask

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,19 +56,19 @@ val shadowVersion: String by project
 val jacocoVersion: String by project
 
 dependencies {
-    "compile"(localGroovy())
-    "compile"(gradleApi())
-    "compile"("org.openjdk.jmh:jmh-core:$jmhVersion")
+    "implementation"(localGroovy())
+    "implementation"(gradleApi())
+    "implementation"("org.openjdk.jmh:jmh-core:$jmhVersion")
     "compileOnly"("org.openjdk.jmh:jmh-generator-bytecode:$jmhVersion")
 
-    "testCompile"("junit:junit:$junitVersion")
-    testCompile("org.spockframework:spock-core:$spockVersion") {
+    "testImplementation"("junit:junit:$junitVersion")
+    testImplementation("org.spockframework:spock-core:$spockVersion") {
         exclude(mapOf("group" to "org.codehaus.groovy", "module" to "groovy-all"))
     }
-    "testCompile"("com.github.jengelman.gradle.plugins:shadow:$shadowVersion")
+    "testImplementation"("com.github.jengelman.gradle.plugins:shadow:$shadowVersion")
 
-    "testCompile"("org.openjdk.jmh:jmh-core:$jmhVersion")
-    "testCompile"("org.openjdk.jmh:jmh-generator-bytecode:$jmhVersion")
+    "testImplementation"("org.openjdk.jmh:jmh-core:$jmhVersion")
+    "testImplementation"("org.openjdk.jmh:jmh-generator-bytecode:$jmhVersion")
 }
 
 tasks {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,6 @@ project_vcs=https://github.com/melix/jmh-gradle-plugin.git
 
 jacocoVersion      = 0.8.4
 jmhVersion         = 1.21
-shadowVersion      = 5.0.0
+shadowVersion      = 5.1.0
 junitVersion       = 4.12
 spockVersion       = 1.2-groovy-2.4

--- a/gradle/funcTest.gradle
+++ b/gradle/funcTest.gradle
@@ -36,8 +36,8 @@ task createClasspathManifest {
 }
 
 dependencies {
-    functionalTestCompile gradleTestKit()
-    functionalTestCompile files(createClasspathManifest)
+    functionalTestImplementation gradleTestKit()
+    functionalTestImplementation files(createClasspathManifest)
 }
 
 compileFunctionalTestJava.dependsOn createClasspathManifest
@@ -62,6 +62,6 @@ idea.module {
         testSourceDirs += it
     }
 
-    scopes.TEST.plus += [configurations.functionalTestCompile]
-    scopes.TEST.plus += [configurations.functionalTestRuntime]
+    scopes.TEST.plus += [configurations.functionalTestCompileClasspath]
+    scopes.TEST.plus += [configurations.functionalTestRuntimeClasspath]
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/funcTest/groovy/me/champeau/gradle/ProjectWithDuplicateDependenciesSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/gradle/ProjectWithDuplicateDependenciesSpec.groovy
@@ -77,9 +77,9 @@ class ProjectWithDuplicateDependenciesSpec extends Specification {
         }
 
         dependencies {
-            compile 'org.apache.commons:commons-lang3:3.0.1'
-            testCompile 'junit:junit:4.12'
-            testCompile 'org.apache.commons:commons-lang3:3.2'
+            implementation 'org.apache.commons:commons-lang3:3.0.1'
+            testImplementation 'junit:junit:4.12'
+            testImplementation 'org.apache.commons:commons-lang3:3.2'
             jmh 'org.apache.commons:commons-lang3:3.4'
         }
 

--- a/src/funcTest/resources/groovy-project/build.gradle
+++ b/src/funcTest/resources/groovy-project/build.gradle
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:2.4.12'
+    implementation 'org.codehaus.groovy:groovy-all:2.4.12'
 }
 
 jmh {

--- a/src/funcTest/resources/java-project-with-test-dependencies/build.gradle
+++ b/src/funcTest/resources/java-project-with-test-dependencies/build.gradle
@@ -23,8 +23,8 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.apache.commons:commons-lang3:3.4'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.apache.commons:commons-lang3:3.4'
 }
 
 jmh {

--- a/src/funcTest/resources/kotlin-project/build.gradle
+++ b/src/funcTest/resources/kotlin-project/build.gradle
@@ -33,7 +33,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib:1.2.0'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.2.0'
 }
 
 jmh {

--- a/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicReference
  * Configures the JMH Plugin.
  */
 class JMHPlugin implements Plugin<Project> {
-    private static boolean IS_GRADLE_MIN_55 = GradleVersion.current().compareTo(GradleVersion.version("5.5-rc-1")) >= 0
+    private static boolean IS_GRADLE_MIN_55 = GradleVersion.current().compareTo(GradleVersion.version("5.5.0")) >= 0
 
     public static final String JMH_CORE_DEPENDENCY = 'org.openjdk.jmh:jmh-core:'
     public static final String JMH_GENERATOR_DEPENDENCY = 'org.openjdk.jmh:jmh-generator-bytecode:'

--- a/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ResolvableDependencies
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.file.FileCopyDetails
 import org.gradle.api.invocation.Gradle

--- a/src/main/groovy/me/champeau/gradle/JMHTask.java
+++ b/src/main/groovy/me/champeau/gradle/JMHTask.java
@@ -15,21 +15,18 @@
  */
 package me.champeau.gradle;
 
-import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.jvm.tasks.Jar;
 import org.gradle.workers.IsolationMode;
-import org.gradle.workers.WorkerConfiguration;
 import org.gradle.workers.WorkerExecutor;
 import org.openjdk.jmh.runner.options.Options;
-import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import javax.inject.Inject;
-import java.io.File;
-import java.util.Arrays;
 
 /**
  * The JMH task converts our {@link JMHPluginExtension extension configuration} into JMH specific
@@ -53,23 +50,20 @@ public class JMHTask extends DefaultTask {
         final Options options = extension.resolveArgs();
         extension.getResultsFile().getParentFile().mkdirs();
 
-        workerExecutor.submit(IsolatedRunner.class, new Action<WorkerConfiguration>() {
-            @Override
-            public void execute(final WorkerConfiguration workerConfiguration) {
-                workerConfiguration.setIsolationMode(IsolationMode.PROCESS);
-                ConfigurationContainer configurations = getProject().getConfigurations();
-                FileCollection classpath = configurations.getByName("jmh").plus(getProject().files(getJarArchive()));
-                if (extension.isIncludeTests()) {
-                    classpath = classpath.plus(configurations.getByName("testRuntimeClasspath"));
-                }
-                // TODO: This isn't quite right.  JMH is already a part of the worker classpath,
-                // but we need it to be part of the "classpath under test" too.
-                // We only need the jar for the benchmarks on the classpath so that the BenchmarkList resource reader
-                // can find the BenchmarkList file in the jar.
-                workerConfiguration.classpath(classpath);
-                workerConfiguration.params(options, classpath.getFiles());
-                workerConfiguration.getForkOptions().getSystemProperties().put(JAVA_IO_TMPDIR, getTemporaryDir());
+        workerExecutor.submit(IsolatedRunner.class, workerConfiguration -> {
+            workerConfiguration.setIsolationMode(IsolationMode.PROCESS);
+            ConfigurationContainer configurations = getProject().getConfigurations();
+            FileCollection classpath = configurations.getByName("jmh").plus(getProject().files(getJarArchive()));
+            if (extension.isIncludeTests()) {
+                classpath = classpath.plus(configurations.getByName("testRuntimeClasspath"));
             }
+            // TODO: This isn't quite right.  JMH is already a part of the worker classpath,
+            // but we need it to be part of the "classpath under test" too.
+            // We only need the jar for the benchmarks on the classpath so that the BenchmarkList resource reader
+            // can find the BenchmarkList file in the jar.
+            workerConfiguration.classpath(classpath);
+            workerConfiguration.params(options, classpath.getFiles());
+            workerConfiguration.getForkOptions().getSystemProperties().put(JAVA_IO_TMPDIR, getTemporaryDir());
         });
     }
 
@@ -78,8 +72,8 @@ public class JMHTask extends DefaultTask {
         super.setDidWork(didWork);
     }
 
-    private File getJarArchive() {
-        return ((Jar)getProject().getTasks().getByName(JMHPlugin.JMH_JAR_TASK_NAME)).getArchivePath();
+    private Provider<RegularFile> getJarArchive() {
+        return ((Jar)getProject().getTasks().getByName(JMHPlugin.JMH_JAR_TASK_NAME)).getArchiveFile();
     }
 
 }


### PR DESCRIPTION
Adds `--include` and `--threads` parameters as POC to adding command line options to the `jmh` task.


Usage:
```
./gradlew jmh --include=MyBenchmark --threads=10
```


Builds on top of the https://github.com/melix/jmh-gradle-plugin/pull/154 PR so ignore those commits. Look at https://github.com/melix/jmh-gradle-plugin/commit/b155f1616df6bd74a312d805456e35ed3a7e7e06.

If you like I can split these PRs and move forward on this one while discussing how to address the jar issues.