### PR TITLE
Fix file descriptor leak through worker classpath

### DIFF
--- a/src/main/groovy/me/champeau/gradle/IsolatedRunner.java
+++ b/src/main/groovy/me/champeau/gradle/IsolatedRunner.java
@@ -16,31 +16,39 @@
 package me.champeau.gradle;
 
 import org.gradle.api.GradleException;
+import org.openjdk.jmh.runner.BenchmarkList;
+import org.openjdk.jmh.runner.CompilerHints;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
-import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Set;
 
 public class IsolatedRunner implements Runnable {
 
     private final Options options;
-    private Set<File> classpathUnderTest;
+    private final Set<File> classpathUnderTest;
+    private final File benchmarkList;
+    private final File compilerHints;
 
     @Inject
-    public IsolatedRunner(final Options options, final Set<File> classpathUnderTest) {
+    public IsolatedRunner(final Options options, final Set<File> classpathUnderTest, File benchmarkList, File compilerHints) {
         this.options = options;
         this.classpathUnderTest = classpathUnderTest;
+        this.benchmarkList = benchmarkList;
+        this.compilerHints = compilerHints;
     }
 
     @Override
     public void run() {
         String originalClasspath = System.getProperty("java.class.path");
         Runner runner = new Runner(options);
+        updateBenchmarkList(runner);
+        updateCompilerHints();
         try {
             System.setProperty("java.class.path", toPath(classpathUnderTest));
             // JMH uses the system property java.class.path to derive the runtime classpath of the forked JVM
@@ -55,6 +63,34 @@ public class IsolatedRunner implements Runnable {
                 System.clearProperty("java.class.path");
             }
         }
+    }
+
+    private void updateBenchmarkList(Runner runner) {
+        BenchmarkList benchmarkList = BenchmarkList.fromFile(this.benchmarkList.getAbsolutePath());
+        try {
+            Field listField = runner.getClass().getDeclaredField("list");
+            makeWriteable(listField);
+            listField.set(runner, benchmarkList);
+        } catch (Exception e) {
+            throw new GradleException("Error instantiating benchmarks", e);
+        }
+    }
+    private void updateCompilerHints() {
+        CompilerHints compilerHints = CompilerHints.fromFile(this.compilerHints.getAbsolutePath());
+        try {
+            Field listField = CompilerHints.class.getDeclaredField("defaultList");
+            makeWriteable(listField);
+            listField.set(null, compilerHints);
+        } catch (Exception e) {
+            throw new GradleException("Error instantiating benchmarks", e);
+        }
+    }
+
+    private void makeWriteable(Field listField) throws NoSuchFieldException, IllegalAccessException {
+        listField.setAccessible(true);
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(listField, listField.getModifiers() & ~Modifier.FINAL);
     }
 
     private String toPath(Set<File> classpathUnderTest) {

--- a/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/JMHPlugin.groovy
@@ -89,6 +89,8 @@ class JMHPlugin implements Plugin<Project> {
         createTask(project, JMH_NAME, JMHTask) {
             it.group JMH_GROUP
             it.dependsOn project.jmhJar
+            it.benchmarkList = new File(jmhGeneratedResourcesDir, "META-INF/BenchmarkList")
+            it.compilerHints = new File(jmhGeneratedResourcesDir, "/META-INF/CompilerHints")
         }
 
         configureIDESupport(project)

--- a/src/main/groovy/me/champeau/gradle/JMHTask.java
+++ b/src/main/groovy/me/champeau/gradle/JMHTask.java
@@ -27,6 +27,7 @@ import org.gradle.workers.WorkerExecutor;
 import org.openjdk.jmh.runner.options.Options;
 
 import javax.inject.Inject;
+import java.io.File;
 
 /**
  * The JMH task converts our {@link JMHPluginExtension extension configuration} into JMH specific
@@ -39,6 +40,9 @@ public class JMHTask extends DefaultTask {
 
     private final WorkerExecutor workerExecutor;
 
+    private File benchmarkList;
+    private File compilerHints;
+
     @Inject
     public JMHTask(final WorkerExecutor workerExecutor) {
         this.workerExecutor = workerExecutor;
@@ -48,21 +52,18 @@ public class JMHTask extends DefaultTask {
     public void before() {
         final JMHPluginExtension extension = getProject().getExtensions().getByType(JMHPluginExtension.class);
         final Options options = extension.resolveArgs();
+
         extension.getResultsFile().getParentFile().mkdirs();
 
         workerExecutor.submit(IsolatedRunner.class, workerConfiguration -> {
             workerConfiguration.setIsolationMode(IsolationMode.PROCESS);
             ConfigurationContainer configurations = getProject().getConfigurations();
-            FileCollection classpath = configurations.getByName("jmh").plus(getProject().files(getJarArchive()));
+            workerConfiguration.classpath(configurations.getByName("jmh"));
+            FileCollection benchmarkClasspath = configurations.getByName("jmh").plus(getProject().files(getJarArchive()));
             if (extension.isIncludeTests()) {
-                classpath = classpath.plus(configurations.getByName("testRuntimeClasspath"));
+                benchmarkClasspath = benchmarkClasspath.plus(configurations.getByName("testRuntimeClasspath"));
             }
-            // TODO: This isn't quite right.  JMH is already a part of the worker classpath,
-            // but we need it to be part of the "classpath under test" too.
-            // We only need the jar for the benchmarks on the classpath so that the BenchmarkList resource reader
-            // can find the BenchmarkList file in the jar.
-            workerConfiguration.classpath(classpath);
-            workerConfiguration.params(options, classpath.getFiles());
+            workerConfiguration.params(options, benchmarkClasspath.getFiles(), benchmarkList, compilerHints);
             workerConfiguration.getForkOptions().getSystemProperties().put(JAVA_IO_TMPDIR, getTemporaryDir());
         });
     }
@@ -76,4 +77,11 @@ public class JMHTask extends DefaultTask {
         return ((Jar)getProject().getTasks().getByName(JMHPlugin.JMH_JAR_TASK_NAME)).getArchiveFile();
     }
 
+    public void setBenchmarkList(File benchmarkList) {
+        this.benchmarkList = benchmarkList;
+    }
+
+    public void setCompilerHints(File compilerHints) {
+        this.compilerHints = compilerHints;
+    }
 }

--- a/src/main/groovy/me/champeau/gradle/JmhBytecodeGeneratorTask.groovy
+++ b/src/main/groovy/me/champeau/gradle/JmhBytecodeGeneratorTask.groovy
@@ -34,7 +34,6 @@ class JmhBytecodeGeneratorTask extends DefaultTask {
     @OutputDirectory
     File generatedSourcesDir
 
-
     @Input
     String generatorType = 'default'
 
@@ -48,12 +47,12 @@ class JmhBytecodeGeneratorTask extends DefaultTask {
         def workerExecutor = getServices().get(WorkerExecutor)
         workerExecutor.submit(JmhBytecodeGeneratorRunnable) { WorkerConfiguration config ->
             config.isolationMode = IsolationMode.PROCESS
-            def classpath = runtimeClasspath.files
+            config.classpath = project.configurations.getByName("jmh");
+            def benchmarkClasspath = runtimeClasspath.files
             if (includeTests) {
-                classpath += testClasses.files + testRuntimeClasspath.files
+                benchmarkClasspath += testClasses.files + testRuntimeClasspath.files
             }
-            config.classpath = classpath
-            config.params(classesDirs.files as File[], generatedSourcesDir, generatedClassesDir, generatorType)
+            config.params(benchmarkClasspath as File[], classesDirs.files as File[], generatedSourcesDir, generatedClassesDir, generatorType)
         }
     }
 


### PR DESCRIPTION
Workers created through the worker API live as long as the Gradle daemon.
Therefor, they should not have any JARs on their classpath that are part
of the project being built. Otherwise, the worker keeps these JARs open,
leading to a file descriptor leak and an unability to clean the project
on Windows. Also, on every change to the dependencies, a new worker would
be created, greatly increasing memory pressure on the system. Finally,
the workers of different subprojects would be incompatible due to their
different classpaths, increasing the number of spwawned workers even more.

This fix changes the worker such that only JMH is put on the worker classpath.
The project's own dependencies are passed to the worker as arguments.
Some trickery was necessary, because JMH insists on looking for project-specific
files on its own classpath. This should probably be reported as a bug to JMH.
It should either look on the Thread's context classloader (which we could change)
or make these locations externally configurable on the Runner class.

Fixes #170, #163