### PR TITLE
Make the "download" badge point to the plugin portal

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@
 
 image:http://img.shields.io/travis/melix/jmh-gradle-plugin/master.svg["Build Status (travis)", link="https://travis-ci.org/melix/jmh-gradle-plugin"]
 image:http://img.shields.io/coveralls/melix/jmh-gradle-plugin/master.svg["Coverage Status (coveralls)", link="https://coveralls.io/r/melix/jmh-gradle-plugin"]
-image:https://api.bintray.com/packages/melix/gradle-plugins/jmh-gradle-plugin/images/download.svg[Download, link="https://bintray.com/melix/gradle-plugins/jmh-gradle-plugin"]
+image:https://img.shields.io/maven-metadata/v.svg?metadataUrl=https%3A%2F%2Fplugins.gradle.org%2Fm2%2Fme%2Fchampeau%2Fgradle%2Fjmh%2Fme.champeau.gradle.jmh.gradle.plugin%2Fmaven-metadata.xml&label=plugin%20portal[Download, link="https://plugins.gradle.org/plugin/me.champeau.gradle.jmh"]
 image:http://img.shields.io/badge/license-ASF2-blue.svg["Apache License 2", link="http://www.apache.org/licenses/LICENSE-2.0.txt"]
 
 This plugin integrates the http://openjdk.java.net/projects/code-tools/jmh/[JMH micro-benchmarking framework] with Gradle.


### PR DESCRIPTION
The versions on bintray seem outdated and point to `0.2.0` instead of `0.5.2`