### PR TITLE
Fix error message for unsupported Gradle versions

### DIFF
--- a/src/funcTest/groovy/me/champeau/jmh/UnsupportedGradleVersionSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/jmh/UnsupportedGradleVersionSpec.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.jmh
+
+import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.util.GradleVersion
+import spock.lang.Unroll
+
+@Unroll
+class UnsupportedGradleVersionSpec extends AbstractFuncSpec {
+
+    def "Run project with dependencies on test sources (#gradleVersion)"() {
+
+        given:
+        usingSample('java-project-with-test-dependencies')
+        usingGradleVersion(gradleVersion)
+
+        when:
+        def result = buildAndFail("jmh")
+
+        then:
+	result.output.contains('Please upgrade Gradle or use an older version of the JMH Gradle plugin.')
+
+        where:
+        gradleVersion << GradleVersion.version('6.7')
+    }
+}

--- a/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
@@ -37,7 +37,8 @@ import org.gradle.util.GradleVersion
  * Configures the JMH Plugin.
  */
 class JMHPlugin implements Plugin<Project> {
-    private static boolean IS_GRADLE_MIN = GradleVersion.current() >= GradleVersion.version('6.8')
+    private static GradleVersion GRADLE_MIN = GradleVersion.version('6.8')
+    private static boolean IS_GRADLE_MIN = GradleVersion.current() >= GRADLE_MIN
 
     public static final String JMH_CORE_DEPENDENCY = 'org.openjdk.jmh:jmh-core:'
     public static final String JMH_GENERATOR_DEPENDENCY = 'org.openjdk.jmh:jmh-generator-bytecode:'
@@ -99,7 +100,7 @@ class JMHPlugin implements Plugin<Project> {
 
     private static void assertMinimalGradleVersion() {
         if (!IS_GRADLE_MIN) {
-            throw new RuntimeException("This version of the JMH Gradle plugin requires Gradle 6+, you are using ${GradleVersion.current().version}. Please upgrade Gradle or use an older version of the plugin.");
+            throw new RuntimeException("This version of the JMH Gradle plugin requires ${GRADLE_MIN.version}+, you are using ${GradleVersion.current().version}. Please upgrade Gradle or use an older version of the JMH Gradle plugin.");
         }
     }
 


### PR DESCRIPTION
Fix error message when the JMH Gradle plugin is being used with an unsupported version of Gradle.

As of version 0.6.4, the plugin only mentions Gradle 6+ as requirement, which makes the error message a bit unclear.

Example with Gradle 6.7.1:
```
* What went wrong:
An exception occurred applying plugin request [id: 'me.champeau.jmh', version: '0.6.4']
> Failed to apply plugin 'me.champeau.jmh'.
   > This version of the JMH Gradle plugin requires Gradle 6+, you are using 6.7.1. Please upgrade Gradle or use an older version of the plugin.
```

This PR is using the minimal Gradle version defined in `JMHPlugin` to build the error message and adds a functional test to verify the message is correct.