### PR TITLE
Modify Kotlin functional test to use internal code

### DIFF
--- a/src/funcTest/resources/kotlin-project/src/main/kotlin/me/champeau/gradle/jmh/mixlang/Internal.kt
+++ b/src/funcTest/resources/kotlin-project/src/main/kotlin/me/champeau/gradle/jmh/mixlang/Internal.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,25 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package me.champeau.jmh.mixlang
+package me.champeau.gradle.jmh.mixlang
 
-import me.champeau.gradle.jmh.mixlang.doNothing
-import org.openjdk.jmh.annotations.*
-
-@State(Scope.Benchmark)
-@Fork(1)
-@Warmup(iterations = 0)
-@Measurement(iterations = 1)
-open class KotlinBenchmark {
-    var value: Double = 0.0
-
-    @Setup
-    fun setUp(): Unit {
-        value = 3.0
-        doNothing()
-    }
-
-    @Benchmark
-    fun sqrtBenchmark(): Double = Math.sqrt(value)
-
-}
+internal fun doNothing() {}

--- a/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
@@ -94,13 +94,23 @@ class JMHPlugin implements Plugin<Project> {
             it.humanOutputFile.convention(extension.humanOutputFile)
         }
 
-
+        configureKotlin(project)
         configureIDESupport(project)
     }
 
     private static void assertMinimalGradleVersion() {
         if (!IS_GRADLE_MIN) {
             throw new RuntimeException("This version of the JMH Gradle plugin requires ${GRADLE_MIN.version}+, you are using ${GradleVersion.current().version}. Please upgrade Gradle or use an older version of the JMH Gradle plugin.");
+        }
+    }
+
+    private static void configureKotlin(Project project) {
+        // Associate the JMH Kotlin compilation with the main compilation. This allows resolution of Kotlin "internal" visibility.
+        project.pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
+            def kotlinCompilations = project.extensions.getByName("kotlin").target.compilations
+            def mainCompilation = kotlinCompilations.getByName("main")
+            def jmhCompilation = kotlinCompilations.getByName(JMH_NAME)
+            jmhCompilation.associateWith(mainCompilation)
         }
     }
 


### PR DESCRIPTION
Kotlin has the concept of "internal" code - code which is only accessible to the current "module". When running JMH benchmarks, I believe most developers would consider their benchmarks to be part of the same module. Right now, the JMH plugin does not resolve internal APIs from the main sourceset to the jmh sourceset.

Note that this change set only demonstrates the issue, it does not fix it.