### PR TITLE
Fix a bug where benchmarkParameters are not respected

### DIFF
--- a/src/funcTest/groovy/me/champeau/jmh/ParameterSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/jmh/ParameterSpec.groovy
@@ -13,20 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins {
-    id 'java'
-    id 'me.champeau.jmh'
-}
+package me.champeau.jmh
 
-repositories {
-    mavenCentral()
-}
 
-jmh {
-    resultFormat = 'csv'
-    benchmarkMode = ['thrpt','ss']
-    resultsFile = file('build/reports/benchmarks.csv')
-    def aParams = project.objects.listProperty(String).value(['a'])
-    benchmarkParameters = [a: aParams]
-    failOnError = true
+import spock.lang.Unroll
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+@Unroll
+class ParameterSpec extends AbstractFuncSpec {
+
+    def "Executes benchmarks with parameters"() {
+
+        given:
+        usingSample("java-project")
+
+        when:
+        def result = build("jmh")
+
+        then:
+        result.task(":jmh").outcome == SUCCESS
+        !result.output.contains('parameter option not respected')
+    }
 }

--- a/src/funcTest/resources/java-project/src/jmh/java/me/champeau/gradle/jmh/mixlang/JavaBenchmark.java
+++ b/src/funcTest/resources/java-project/src/jmh/java/me/champeau/gradle/jmh/mixlang/JavaBenchmark.java
@@ -24,13 +24,19 @@ import org.openjdk.jmh.annotations.*;
 public class JavaBenchmark {
     private double value;
 
+    @Param({"a", "b"})
+    String a;
+
     @Setup
     public void setUp() {
         value = 3.0;
     }
 
     @Benchmark
-    public double sqrtBenchmark(){
+    public double sqrtBenchmark() {
+        if (!"a".equals(a)) {
+            throw new RuntimeException("parameter option not respected");
+        }
         return Math.sqrt(value);
     }
 }

--- a/src/main/java/me/champeau/jmh/ParameterConverter.java
+++ b/src/main/java/me/champeau/jmh/ParameterConverter.java
@@ -128,7 +128,7 @@ public class ParameterConverter {
             map.forEach((key, listProperty) -> {
                 List<String> value = listProperty.get();
                 for (String str : value) {
-                    options.add(" -" + option);
+                    options.add("-" + option);
                     options.add(key + "=" + str);
                 }
             });


### PR DESCRIPTION
**Motivation**

Benchmark fails to run due to an extra space

```
> Task :jmh FAILED
[-bm, thrpt,ss, -foe, 1, -gc, 0,  -p, a=a, -rf, csv, -rff, /private/var/folders/5t/dnxsrx2d3r3c602x4z01t2vw0000gn/T/spock_Executes_benchmarks_0_temporaryFolder6367835791579630067/build/reports/benchmarks.csv]
No matching benchmarks. Miss-spelled regexp?
```

**Modification**
- Remove the extra whitespace and add a functional test