### PR TITLE
Add dependency on `compileTestJava` if `includeTests=true`

### DIFF
--- a/src/funcTest/groovy/me/champeau/jmh/ProjectWithTestDependenciesSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/jmh/ProjectWithTestDependenciesSpec.groovy
@@ -37,4 +37,21 @@ class ProjectWithTestDependenciesSpec extends AbstractFuncSpec {
         where:
         gradleVersion << TESTED_GRADLE_VERSIONS
     }
+
+    def "Run project with dependencies on test sources and configure-on-demand (#gradleVersion)"() {
+
+        given:
+        usingSample('java-project-with-test-dependencies')
+        usingGradleVersion(gradleVersion)
+
+        when:
+        def result = build("--configure-on-demand", "jmh")
+
+        then:
+        result.task(":compileTestJava").outcome == TaskOutcome.SUCCESS
+        !result.output.contains("Task ':compileJmhJava' uses this output of task ':compileTestJava' without declaring an explicit or implicit dependency.")
+
+        where:
+        gradleVersion << TESTED_GRADLE_VERSIONS
+    }
 }

--- a/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
@@ -62,7 +62,7 @@ class JMHPlugin implements Plugin<Project> {
 
         def hasShadow = project.plugins.findPlugin('com.github.johnrengelman.shadow') != null
 
-        createJmhSourceSet(project)
+        createJmhSourceSet(project, extension)
 
         registerBuildListener(project, extension)
 
@@ -167,7 +167,7 @@ class JMHPlugin implements Plugin<Project> {
         }
     }
 
-    private void createJmhSourceSet(Project project) {
+    private void createJmhSourceSet(Project project, JmhParameters extension) {
         project.sourceSets {
             jmh {
                 compileClasspath += main.output
@@ -181,6 +181,12 @@ class JMHPlugin implements Plugin<Project> {
 
             jmhCompileClasspath.extendsFrom(implementation, compileOnly)
             jmhRuntimeClasspath.extendsFrom(implementation, runtimeOnly)
+        }
+
+        if (extension.includeTests.get()) {
+            project.tasks.named("compileJmhJava", JavaCompile.class).configure {
+                dependsOn(project.tasks.named(JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME, JavaCompile.class))
+            }
         }
     }
 


### PR DESCRIPTION
The JMH Gradle Plugin adds an implicit dependency on the test classes when `includeTests` is `true` (default).
In order for Gradle acknowledge this dependency and work well with the configure-on-demand feature enabled, the JMH Gradle Plugin should register this task dependency.

Fixes #203