### PR TITLE
Use list for map parameter values

### DIFF
--- a/src/funcTest/resources/java-project/build.gradle
+++ b/src/funcTest/resources/java-project/build.gradle
@@ -26,7 +26,6 @@ jmh {
     resultFormat = 'csv'
     benchmarkMode = ['thrpt','ss']
     resultsFile = file('build/reports/benchmarks.csv')
-    def aParams = project.objects.listProperty(String).value(['a'])
-    benchmarkParameters = [a: aParams]
+    benchmarkParameters = [a: ['a']]
     failOnError = true
 }

--- a/src/main/java/me/champeau/jmh/JmhParameters.java
+++ b/src/main/java/me/champeau/jmh/JmhParameters.java
@@ -15,6 +15,8 @@
  */
 package me.champeau.jmh;
 
+import java.util.List;
+
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
@@ -75,7 +77,7 @@ public interface JmhParameters extends WithJavaToolchain {
     Property<Integer> getOperationsPerInvocation();
 
     @Input
-    MapProperty<String, ListProperty<String>> getBenchmarkParameters();
+    MapProperty<String, List<String>> getBenchmarkParameters();
 
     @Input
     @Optional

--- a/src/main/java/me/champeau/jmh/ParameterConverter.java
+++ b/src/main/java/me/champeau/jmh/ParameterConverter.java
@@ -122,11 +122,11 @@ public class ParameterConverter {
 
     }
 
-    private static void addMapOption(List<String> options, MapProperty<String, ListProperty<String>> params, String option) {
+    private static void addMapOption(List<String> options, MapProperty<String, List<String>> params, String option) {
         if (params.isPresent()) {
-            Map<String, ListProperty<String>> map = params.get();
-            map.forEach((key, listProperty) -> {
-                List<String> value = listProperty.get();
+            Map<String, List<String>> map = params.get();
+            map.forEach((key, list) -> {
+                List<String> value = list;
                 for (String str : value) {
                     options.add("-" + option);
                     options.add(key + "=" + str);


### PR DESCRIPTION
**Motivation**

ex) https://github.com/line/armeria/pull/3811

It seems like most usages assume that the parameter values are `List` rather than `ListProperty`
ref: https://github.com/search?l=Gradle&p=5&q=benchmarkParameters&type=Code

Using previous code naively, the following exception is raised:
```
> Error while evaluating property 'benchmarkParameters' of task ':benchmarks:jmh'
   > Failed to calculate the value of task ':benchmarks:jmh' property 'benchmarkParameters'.
      > Failed to query the value of extension 'jmh' property 'benchmarkParameters'.
         > Cannot get the value of a property of type java.util.Map with value type org.gradle.api.provider.ListProperty as the source contains a value of type java.util.ArrayList.
```

A workaround exists so I wouldn't say this is critical, but I was wondering if this API change was intentional.

**Modification**

- Modify `addMapOption` to receive a `List` value instead of a `ListProperty` value