### PR TITLE
Bump JMH to 1.35

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ project_issues=https://github.com/melix/jmh-gradle-plugin/issues
 project_vcs=https://github.com/melix/jmh-gradle-plugin.git
 
 jacocoVersion      = 0.8.4
-jmhVersion         = 1.29
+jmhVersion         = 1.35
 shadowVersion      = 5.1.0
 spockVersion       = 2.0-groovy-3.0

--- a/src/main/java/me/champeau/jmh/DefaultsConfigurer.java
+++ b/src/main/java/me/champeau/jmh/DefaultsConfigurer.java
@@ -21,7 +21,7 @@ import org.gradle.api.file.DuplicatesStrategy;
 
 class DefaultsConfigurer {
     public static void configureDefaults(JmhParameters params, Project project) {
-        params.getJmhVersion().convention("1.29");
+        params.getJmhVersion().convention("1.35");
         params.getIncludeTests().convention(true);
         params.getZip64().convention(false);
         params.getDuplicateClassesStrategy().convention(DuplicatesStrategy.INCLUDE);


### PR DESCRIPTION
Really dumb to PR to bump JMH to 1.35. Since 1.29 here's some nice improvements (among others and bug-fixes):

- Better JDK 17 support
- Supports async-profiler 2.0
- Compiler Blackholes auto-detection for current JVM

