### PR TITLE
Adds environment variables

### DIFF
--- a/src/main/java/me/champeau/jmh/DefaultsConfigurer.java
+++ b/src/main/java/me/champeau/jmh/DefaultsConfigurer.java
@@ -84,6 +84,7 @@ class DefaultsConfigurer {
         into.getZip64().convention(from.getZip64());
         into.getDuplicateClassesStrategy().convention(from.getDuplicateClassesStrategy());
         into.getJavaLauncher().convention(from.getJavaLauncher());
+        into.getEnvironmentVariables().convention(from.getEnvironmentVariables());
     }
 
 }

--- a/src/main/java/me/champeau/jmh/JMHTask.java
+++ b/src/main/java/me/champeau/jmh/JMHTask.java
@@ -31,7 +31,9 @@ import org.gradle.process.ExecOperations;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The JMH task is responsible for launching a JMH benchmark.
@@ -65,13 +67,16 @@ public abstract class JMHTask extends DefaultTask implements JmhParameters {
     @TaskAction
     public void callJmh() {
         List<String> jmhArgs = new ArrayList<>();
+        Map<String, String> env = new HashMap<>();
         ParameterConverter.collectParameters(this, jmhArgs);
+        ParameterConverter.collectEnvironment(this, env);
         getLogger().info("Running JMH with arguments: " + jmhArgs);
         getExecOperations().javaexec(spec -> {
             spec.setClasspath(computeClasspath());
             spec.getMainClass().set("org.openjdk.jmh.Main");
             spec.args(jmhArgs);
             spec.systemProperty(JAVA_IO_TMPDIR, getTemporaryDir().getAbsolutePath());
+            spec.environment(env);
             Provider<JavaLauncher> javaLauncher = getJavaLauncher();
             if (javaLauncher.isPresent()) {
                 spec.executable(javaLauncher.get().getExecutablePath().getAsFile());

--- a/src/main/java/me/champeau/jmh/JmhParameters.java
+++ b/src/main/java/me/champeau/jmh/JmhParameters.java
@@ -145,6 +145,10 @@ public interface JmhParameters extends WithJavaToolchain {
     @Input
     Property<DuplicatesStrategy> getDuplicateClassesStrategy();
 
+    @Input
+    @Optional
+    MapProperty<String, String> getEnvironmentVariables();
+
     RegularFileProperty getHumanOutputFile();
 
     RegularFileProperty getResultsFile();

--- a/src/main/java/me/champeau/jmh/ParameterConverter.java
+++ b/src/main/java/me/champeau/jmh/ParameterConverter.java
@@ -26,6 +26,13 @@ import java.util.Map;
 import static java.util.stream.Collectors.joining;
 
 public class ParameterConverter {
+    public static void collectEnvironment(JMHTask jmhTask, Map<String, String> env) {
+        MapProperty<String, String> environmentVariables = jmhTask.getEnvironmentVariables();
+        if (environmentVariables.isPresent()) {
+            env.putAll(environmentVariables.get());
+        }
+    }
+
     public static void collectParameters(JmhParameters from, final List<String> into) {
         // ordered as when running -help
         addOption(into, from.getIncludes(), "");


### PR DESCRIPTION
Sometimes it is necessary to pass some environment variables to configure
the JVM process (in particular when native libraries are involved). And
when there's no system property equivalent, or when it's not possible to do in the benchmark setup (e.g. `LD_PRELOAD`, `JAVA_LIBRARY_PATH`).

Alas, JMH does not support to set environment variable on the forked
process, however it will propagate the ones that it has been launched with.
E.g.

```
env JAVA_LIBRARY_PATH=/somewhere java -jar bench.jar
```

This change aims at providing the ability to pass the variable to JMH so it cna be used on the JMH forked process.