### PR TITLE
Adds environment variables

### DIFF
--- a/src/funcTest/groovy/me/champeau/jmh/JmhWithEnvironmentSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/jmh/JmhWithEnvironmentSpec.groovy
@@ -1,0 +1,27 @@
+package me.champeau.jmh
+
+import org.gradle.util.GradleVersion
+import spock.lang.Unroll
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+@Unroll
+class JmhWithEnvironmentSpec extends AbstractFuncSpec {
+    def "Executes benchmarks with environment"() {
+
+        given:
+        usingSample("java-project-for-env-support")
+        usingGradleVersion(gradleVersion)
+
+        when:
+        def result = build("jmh")
+
+        then:
+        result.task(":jmh").outcome == SUCCESS
+        result.output.contains('got MY_ENV1=my_value1')
+        result.output.contains('got MY_ENV2=my_value2')
+
+        where:
+        gradleVersion << TESTED_GRADLE_VERSIONS
+    }
+}

--- a/src/funcTest/groovy/me/champeau/jmh/JmhWithEnvironmentSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/jmh/JmhWithEnvironmentSpec.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package me.champeau.jmh
 
 import org.gradle.util.GradleVersion

--- a/src/funcTest/resources/java-project-for-env-support/build.gradle
+++ b/src/funcTest/resources/java-project-for-env-support/build.gradle
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+    id 'java'
+    id 'me.champeau.jmh'
+}
+
+repositories {
+    mavenCentral()
+}
+
+jmh {
+    resultFormat = 'csv'
+    benchmarkMode = ['thrpt', 'ss']
+    resultsFile = file('build/reports/benchmarks.csv')
+    def aParams = project.objects.listProperty(String).value(['a'])
+    benchmarkParameters = [a: aParams]
+    failOnError = true
+
+    environment = ['MY_ENV1': 'my_value1',
+                   'MY_ENV2': 'my_value2']
+}

--- a/src/funcTest/resources/java-project-for-env-support/settings.gradle
+++ b/src/funcTest/resources/java-project-for-env-support/settings.gradle
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2014-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+rootProject.name = "java-project-for-env-support"

--- a/src/funcTest/resources/java-project-for-env-support/src/jmh/java/me/champeau/gradle/jmh/env/JavaWithEnvBenchmark.java
+++ b/src/funcTest/resources/java-project-for-env-support/src/jmh/java/me/champeau/gradle/jmh/env/JavaWithEnvBenchmark.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.jmh.env;
+
+import org.openjdk.jmh.annotations.*;
+
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 0)
+@Measurement(iterations = 1)
+public class JavaWithEnvBenchmark {
+    private double value;
+
+    @Setup
+    public void setUp() {
+        System.out.printf("got MY_ENV1=%s%n", System.getenv("MY_ENV1"))
+                  .printf("got MY_ENV2=%s%n", System.getenv("MY_ENV2"));
+        value = 3.0;
+    }
+
+    @Benchmark
+    public double sqrtBenchmark() {
+        return Math.sqrt(value);
+    }
+}

--- a/src/main/java/me/champeau/jmh/DefaultsConfigurer.java
+++ b/src/main/java/me/champeau/jmh/DefaultsConfigurer.java
@@ -84,6 +84,7 @@ class DefaultsConfigurer {
         into.getZip64().convention(from.getZip64());
         into.getDuplicateClassesStrategy().convention(from.getDuplicateClassesStrategy());
         into.getJavaLauncher().convention(from.getJavaLauncher());
+        into.getEnvironmentVariables().convention(from.getEnvironmentVariables());
     }
 
 }

--- a/src/main/java/me/champeau/jmh/DefaultsConfigurer.java
+++ b/src/main/java/me/champeau/jmh/DefaultsConfigurer.java
@@ -84,7 +84,7 @@ class DefaultsConfigurer {
         into.getZip64().convention(from.getZip64());
         into.getDuplicateClassesStrategy().convention(from.getDuplicateClassesStrategy());
         into.getJavaLauncher().convention(from.getJavaLauncher());
-        into.getEnvironmentVariables().convention(from.getEnvironmentVariables());
+        into.getEnvironment().convention(from.getEnvironment());
     }
 
 }

--- a/src/main/java/me/champeau/jmh/JMHTask.java
+++ b/src/main/java/me/champeau/jmh/JMHTask.java
@@ -31,7 +31,9 @@ import org.gradle.process.ExecOperations;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The JMH task is responsible for launching a JMH benchmark.
@@ -65,13 +67,16 @@ public abstract class JMHTask extends DefaultTask implements JmhParameters {
     @TaskAction
     public void callJmh() {
         List<String> jmhArgs = new ArrayList<>();
+        Map<String, String> env = new HashMap<>();
         ParameterConverter.collectParameters(this, jmhArgs);
+        ParameterConverter.collectEnvironment(this, env);
         getLogger().info("Running JMH with arguments: " + jmhArgs);
         getExecOperations().javaexec(spec -> {
             spec.setClasspath(computeClasspath());
             spec.getMainClass().set("org.openjdk.jmh.Main");
             spec.args(jmhArgs);
             spec.systemProperty(JAVA_IO_TMPDIR, getTemporaryDir().getAbsolutePath());
+            spec.environment(env);
             Provider<JavaLauncher> javaLauncher = getJavaLauncher();
             if (javaLauncher.isPresent()) {
                 spec.executable(javaLauncher.get().getExecutablePath().getAsFile());

--- a/src/main/java/me/champeau/jmh/JMHTask.java
+++ b/src/main/java/me/champeau/jmh/JMHTask.java
@@ -31,9 +31,7 @@ import org.gradle.process.ExecOperations;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * The JMH task is responsible for launching a JMH benchmark.
@@ -67,16 +65,14 @@ public abstract class JMHTask extends DefaultTask implements JmhParameters {
     @TaskAction
     public void callJmh() {
         List<String> jmhArgs = new ArrayList<>();
-        Map<String, String> env = new HashMap<>();
         ParameterConverter.collectParameters(this, jmhArgs);
-        ParameterConverter.collectEnvironment(this, env);
         getLogger().info("Running JMH with arguments: " + jmhArgs);
         getExecOperations().javaexec(spec -> {
             spec.setClasspath(computeClasspath());
             spec.getMainClass().set("org.openjdk.jmh.Main");
             spec.args(jmhArgs);
             spec.systemProperty(JAVA_IO_TMPDIR, getTemporaryDir().getAbsolutePath());
-            spec.environment(env);
+            spec.environment(getEnvironment().get());
             Provider<JavaLauncher> javaLauncher = getJavaLauncher();
             if (javaLauncher.isPresent()) {
                 spec.executable(javaLauncher.get().getExecutablePath().getAsFile());

--- a/src/main/java/me/champeau/jmh/JmhParameters.java
+++ b/src/main/java/me/champeau/jmh/JmhParameters.java
@@ -147,7 +147,7 @@ public interface JmhParameters extends WithJavaToolchain {
 
     @Input
     @Optional
-    MapProperty<String, String> getEnvironmentVariables();
+    MapProperty<String, Object> getEnvironment();
 
     RegularFileProperty getHumanOutputFile();
 

--- a/src/main/java/me/champeau/jmh/JmhParameters.java
+++ b/src/main/java/me/champeau/jmh/JmhParameters.java
@@ -145,6 +145,10 @@ public interface JmhParameters extends WithJavaToolchain {
     @Input
     Property<DuplicatesStrategy> getDuplicateClassesStrategy();
 
+    @Input
+    @Optional
+    MapProperty<String, String> getEnvironmentVariables();
+
     RegularFileProperty getHumanOutputFile();
 
     RegularFileProperty getResultsFile();

--- a/src/main/java/me/champeau/jmh/ParameterConverter.java
+++ b/src/main/java/me/champeau/jmh/ParameterConverter.java
@@ -26,13 +26,6 @@ import java.util.Map;
 import static java.util.stream.Collectors.joining;
 
 public class ParameterConverter {
-    public static void collectEnvironment(JMHTask jmhTask, Map<String, String> env) {
-        MapProperty<String, String> environmentVariables = jmhTask.getEnvironmentVariables();
-        if (environmentVariables.isPresent()) {
-            env.putAll(environmentVariables.get());
-        }
-    }
-
     public static void collectParameters(JmhParameters from, final List<String> into) {
         // ordered as when running -help
         addOption(into, from.getIncludes(), "");

--- a/src/main/java/me/champeau/jmh/ParameterConverter.java
+++ b/src/main/java/me/champeau/jmh/ParameterConverter.java
@@ -26,6 +26,13 @@ import java.util.Map;
 import static java.util.stream.Collectors.joining;
 
 public class ParameterConverter {
+    public static void collectEnvironment(JMHTask jmhTask, Map<String, String> env) {
+        MapProperty<String, String> environmentVariables = jmhTask.getEnvironmentVariables();
+        if (environmentVariables.isPresent()) {
+            env.putAll(environmentVariables.get());
+        }
+    }
+
     public static void collectParameters(JmhParameters from, final List<String> into) {
         // ordered as when running -help
         addOption(into, from.getIncludes(), "");


### PR DESCRIPTION
This proposed change is about the support of _environment variables_ when launching the jmh jar. (Because the `org.openjdk.jmh.annotations.Fork` don't allow to pass environments).

_The jmh block is of type `JmhParameters` and `WithJavaToolchain` so in order to support a similar API as `JavaExecSpec` it has to be explicitly exposed._

**Current alternative**
The currently API does not allow this so we have to executes the jmh jar outside gradle.

```shell
$ ./gradlew :jmh-panama:jmhJar
$ env JAVA_LIBRARY_PATH=$(grealpath jmh-panama/jni) \
  java -jar jmh-panama/build/libs/jmh-panama-jmh.jar \
  -jvmArgs '-Xms256m -Xmx256m -Djmh.separateClasspathJAR=true --add-modules=jdk.incubator.foreign --enable-native-access=ALL-UNNAMED'
```

**Note**
I didn't see a functional test with jmh options so I'm not sure how you'd want to test that.