### PR TITLE
Replace `setMain` by `getMainClass.set` to support future Gradle 8.0

### DIFF
--- a/src/main/java/me/champeau/jmh/JmhBytecodeGeneratorTask.java
+++ b/src/main/java/me/champeau/jmh/JmhBytecodeGeneratorTask.java
@@ -65,7 +65,7 @@ public abstract class JmhBytecodeGeneratorTask extends DefaultTask implements Wi
 
         for (File classesDir : getClassesDirsToProcess()) {
             getExecOperations().javaexec(spec -> {
-                spec.setMain("org.openjdk.jmh.generators.bytecode.JmhBytecodeGenerator");
+                spec.getMainClass().set("org.openjdk.jmh.generators.bytecode.JmhBytecodeGenerator");
                 spec.classpath(getJmhClasspath(), getRuntimeClasspath(), getClassesDirsToProcess());
                 spec.args(
                         classesDir,


### PR DESCRIPTION
Running jmh with gradle 7.4.1 we now get this warning, this PR replaces this with the new API.

```
> Task :jmh-panama:jmhRunBytecodeGenerator
The JavaExecHandleBuilder.setMain(String) method has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the mainClass property instead. Consult the upgrading guide for further information: https://docs.gradle.org/7.4.1/userguide/upgrading_version_7.html#java_exec_properties
```

This was the only usage left.