### PR TITLE
Remove outdated warning around Groovy version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -230,8 +230,3 @@ duplicate classes which means that it is not possible to predict which one will 
 
 To deal with duplicate files other than classes use
 https://github.com/johnrengelman/shadow/[Shadow Plugin] capabilities, see <<Using JMH Gradle Plugin with Shadow Plugin>>.
-
-== Known issues
-
-If a benchmark is written in Groovy, you must use the same version of Groovy as the one bundled with Gradle. This is
-a limitation of the Gradle Worker API that is going to be fixed in the future.


### PR DESCRIPTION
I believe this warning is out of date, so I propose to remove it from the README. There may be some nuance that I'm missing here, so feel free to tell me if I'm off.

Using Gradle 7.3 and plugin version 0.6.6 in a project that is built using Groovy 2.5, I can write JMH benchmarks in Groovy and they still compile and execute normally.

The first entry in `./gradlew dependencies --configuration jmhCompileClasspath` is `+--- org.codehaus.groovy:groovy-all -> 2.5.14`, even though the bundled version of Groovy in Gradle 7.3 is Groovy 3. Likewise, Groovy 3 is nowhere to be found in those dependencies.

Likewise, the META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule file has this on line 2: `moduleVersion=2.5.14`.

Based on all of that, it looks like this plugin will honor the Groovy version used by your project in Gradle version 7.3. Is there something I'm missing?