### PR TITLE
Make JMH compatible with Gradle 8.0

### DIFF
--- a/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
@@ -126,7 +126,7 @@ class JMHPlugin implements Plugin<Project> {
                 project.idea {
                     module {
                         project.sourceSets.jmh.java.srcDirs.each {
-                            testSourceDirs += project.file(it)
+                            testSources.from(project.file(it))
                         }
                     }
                 }


### PR DESCRIPTION
`IdeaModule.testSourceDirs` is deprecated and scheduled for removal in Gradle 8.0.