### PR TITLE
Remove setCanBeResolved(true)

### DIFF
--- a/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
@@ -316,7 +316,6 @@ class JMHPlugin implements Plugin<Project> {
     private static Configuration configureJmhRuntimeClasspathConfiguration(Project project, JmhParameters extension) {
         def newConfig = project.configurations.findByName(JHM_RUNTIME_CLASSPATH_CONFIGURATION)
         newConfig.setCanBeConsumed(false)
-        newConfig.setCanBeResolved(true)
         newConfig.setVisible(false)
         newConfig.extendsFrom(project.configurations.getByName('jmh'))
         newConfig.extendsFrom(project.configurations.getByName('runtimeClasspath'))


### PR DESCRIPTION
Fixes: The resolvable usage is already allowed on configuration ':jmhRuntimeClasspath'. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Remove the call to setCanBeResolved(true), it has no effect. Consult the upgrading guide for further information: https://docs.gradle.org/8.2/userguide/upgrading_version_8.html#redundant_configuration_usage_activation