### PR TITLE
Mark jmh source set as eclipse test source

### DIFF
--- a/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
@@ -142,7 +142,10 @@ class JMHPlugin implements Plugin<Project> {
             def hasEclipseWtpPlugin = project.plugins.findPlugin(EclipseWtpPlugin)
             if (hasEclipsePlugin != null || hasEclipseWtpPlugin != null) {
                 project.eclipse {
-                    classpath.plusConfigurations += [project.configurations.jmh]
+                    classpath {
+                        plusConfigurations += [project.configurations.jmh]
+                        testSourceSets = [project.sourceSets.test, project.sourceSets.jmh]
+                    }
                 }
             }
         }


### PR DESCRIPTION
This merge request marks the JMH source folder as test source within the Eclipse Project.