### PR TITLE
Do not access 'project.zipTree' in mapping closure

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/funcTest/groovy/me/champeau/jmh/AbstractFuncSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/jmh/AbstractFuncSpec.groovy
@@ -26,6 +26,7 @@ abstract class AbstractFuncSpec extends Specification {
 
     protected static final List<GradleVersion> TESTED_GRADLE_VERSIONS = [
             GradleVersion.version('7.0'),
+            GradleVersion.version('8.0'),
             GradleVersion.current()
     ]
 

--- a/src/funcTest/groovy/me/champeau/jmh/ParameterSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/jmh/ParameterSpec.groovy
@@ -15,7 +15,7 @@
  */
 package me.champeau.jmh
 
-import org.gradle.util.GradleVersion
+
 import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -46,7 +46,8 @@ class ParameterSpec extends AbstractFuncSpec {
 
         then:
         result.task(":jmhJar").outcome == SUCCESS
-        result.output.contains("Calculating task graph as no configuration cache is available for tasks: jmhJar")
+        result.output.contains("Calculating task graph as no configuration cache is available for tasks: jmhJar") ||
+                result.output.contains("Calculating task graph as no cached configuration is available for tasks: jmhJar")
 
         when:
         result = build("jmhJar", "--configuration-cache")

--- a/src/funcTest/groovy/me/champeau/jmh/ParameterSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/jmh/ParameterSpec.groovy
@@ -39,7 +39,6 @@ class ParameterSpec extends AbstractFuncSpec {
 
     def "executes with configuration cache"() {
         given:
-        usingGradleVersion(GradleVersion.version("7.6"))
         usingSample("java-project")
 
         when:

--- a/src/funcTest/groovy/me/champeau/jmh/UnsupportedGradleVersionSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/jmh/UnsupportedGradleVersionSpec.groovy
@@ -15,7 +15,7 @@
  */
 package me.champeau.jmh
 
-import org.gradle.testkit.runner.TaskOutcome
+
 import org.gradle.util.GradleVersion
 import spock.lang.Unroll
 
@@ -32,7 +32,7 @@ class UnsupportedGradleVersionSpec extends AbstractFuncSpec {
         def result = buildAndFail("jmh")
 
         then:
-	result.output.contains('Please upgrade Gradle or use an older version of the JMH Gradle plugin.')
+	    result.output.contains('Please upgrade Gradle or use an older version of the JMH Gradle plugin.')
 
         where:
         gradleVersion << GradleVersion.version('6.9')

--- a/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
@@ -54,7 +54,7 @@ abstract class JMHPlugin implements Plugin<Project> {
     static final String JHM_RUNTIME_CLASSPATH_CONFIGURATION = 'jmhRuntimeClasspath'
 
     @Inject
-    protected abstract ArchiveOperations getArchives()
+    protected abstract ArchiveOperations getArchiveOperations()
 
     void apply(Project project) {
         assertMinimalGradleVersion()
@@ -271,7 +271,7 @@ abstract class JMHPlugin implements Plugin<Project> {
                                                    Provider<Directory> jmhGeneratedClassesDir,
                                                    Configuration runtimeConfiguration) {
         project.tasks.register(JMH_JAR_TASK_NAME, Jar) {
-            def archives = archives
+            def archives = archiveOperations
 
             it.group = JMH_GROUP
             it.dependsOn JMH_TASK_COMPILE_GENERATED_CLASSES_NAME

--- a/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
@@ -41,7 +41,7 @@ import javax.inject.Inject
 /**
  * Configures the JMH Plugin.
  */
-abstract class JMHPlugin implements Plugin<Project> {
+class JMHPlugin implements Plugin<Project> {
     private static GradleVersion GRADLE_MIN = GradleVersion.version('7.0')
     private static boolean IS_GRADLE_MIN = GradleVersion.current() >= GRADLE_MIN
 
@@ -52,9 +52,6 @@ abstract class JMHPlugin implements Plugin<Project> {
     static final String JMH_JAR_TASK_NAME = 'jmhJar'
     static final String JMH_TASK_COMPILE_GENERATED_CLASSES_NAME = 'jmhCompileGeneratedClasses'
     static final String JHM_RUNTIME_CLASSPATH_CONFIGURATION = 'jmhRuntimeClasspath'
-
-    @Inject
-    protected abstract ArchiveOperations getArchiveOperations()
 
     void apply(Project project) {
         assertMinimalGradleVersion()
@@ -271,8 +268,7 @@ abstract class JMHPlugin implements Plugin<Project> {
                                                    Provider<Directory> jmhGeneratedClassesDir,
                                                    Configuration runtimeConfiguration) {
         project.tasks.register(JMH_JAR_TASK_NAME, Jar) {
-            def archives = archiveOperations
-
+            def archives = project.objects.newInstance(ServiceInjection).archiveOperations
             it.group = JMH_GROUP
             it.dependsOn JMH_TASK_COMPILE_GENERATED_CLASSES_NAME
             it.inputs.files project.sourceSets.jmh.output
@@ -336,5 +332,10 @@ abstract class JMHPlugin implements Plugin<Project> {
             }
         }
         newConfig
+    }
+
+    interface ServiceInjection {
+        @Inject
+        ArchiveOperations getArchiveOperations()
     }
 }


### PR DESCRIPTION
This is not supported by the Configuration Cache. Instead, we inject an ArchiveOperations service.

Fixes #229