### PR TITLE
Support `io.github.goooler.shadow` plugin

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -195,8 +195,10 @@ It is possible a dependency on the `test` source set by setting property `includ
 
 == Using JMH Gradle Plugin with Shadow Plugin
 
-Optionally it is possible to use https://github.com/johnrengelman/shadow/[Shadow Plugin] to do actual JMH jar
-creation. The configuration of Shadow Plugin for JMH jar is done via `jmhJar` block.
+Optionally it is possible to use the https://github.com/johnrengelman/shadow/[Shadow Plugin] (or the
+https://github.com/Goooler/shadow[forked Shadow Plugin]) to do actual JMH jar creation. The configuration of
+Shadow Plugin for JMH jar is done via `jmhJar` block.
+
 For example:
 [source,groovy]
 .build.gradle
@@ -231,4 +233,5 @@ However if you do encounter problem with defaut value it means that the classpat
 duplicate classes which means that it is not possible to predict which one will be used when fat jar will generated.
 
 To deal with duplicate files other than classes use
-https://github.com/johnrengelman/shadow/[Shadow Plugin] capabilities, see <<Using JMH Gradle Plugin with Shadow Plugin>>.
+https://github.com/johnrengelman/shadow/[Shadow Plugin] / https://github.com/Goooler/shadow[forked Shadow Plugin]
+capabilities, see <<Using JMH Gradle Plugin with Shadow Plugin>>.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ buildScanRecipes {
 val jmhVersion: String by project
 val spockVersion: String by project
 val shadowVersion: String by project
+val shadowForkVersion: String by project
 val jacocoVersion: String by project
 
 dependencies {
@@ -42,6 +43,7 @@ dependencies {
         exclude(mapOf("group" to "org.codehaus.groovy"))
     }
     pluginsUnderTest("gradle.plugin.com.github.johnrengelman:shadow:$shadowVersion")
+    pluginsUnderTest("io.github.goooler:shadow:$shadowForkVersion")
 
     testImplementation("org.openjdk.jmh:jmh-core:$jmhVersion")
     testImplementation("org.openjdk.jmh:jmh-generator-bytecode:$jmhVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
         exclude(mapOf("group" to "org.codehaus.groovy"))
     }
     pluginsUnderTest("gradle.plugin.com.github.johnrengelman:shadow:$shadowVersion")
-    pluginsUnderTest("io.github.goooler:shadow:$shadowForkVersion")
+    pluginsUnderTest("io.github.goooler.shadow:shadow-gradle-plugin:$shadowForkVersion")
 
     testImplementation("org.openjdk.jmh:jmh-core:$jmhVersion")
     testImplementation("org.openjdk.jmh:jmh-generator-bytecode:$jmhVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,7 @@ project_vcs=https://github.com/melix/jmh-gradle-plugin.git
 jacocoVersion      = 0.8.10
 jmhVersion         = 1.37
 shadowVersion      = 7.1.2
+shadowForkVersion  = 8.1.2
 spockVersion       = 2.3-groovy-3.0
 
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ project_vcs=https://github.com/melix/jmh-gradle-plugin.git
 jacocoVersion      = 0.8.10
 jmhVersion         = 1.37
 shadowVersion      = 7.1.2
-shadowForkVersion  = 8.1.2
+shadowForkVersion  = 8.1.3
 spockVersion       = 2.3-groovy-3.0
 
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8

--- a/src/funcTest/groovy/me/champeau/jmh/AbstractFuncSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/jmh/AbstractFuncSpec.groovy
@@ -30,6 +30,16 @@ abstract class AbstractFuncSpec extends Specification {
             GradleVersion.current()
     ]
 
+    protected static final List<String> TESTED_SHADOW_PLUGINS = [
+            'com.github.johnrengelman.shadow',
+            'io.github.goooler.shadow'
+    ]
+
+    protected static final Map<String, String> TESTED_SHADOW_PLUGIN_FOLDERS = [
+            'com.github.johnrengelman.shadow':  'shadow',
+            'io.github.goooler.shadow':         'forked-shadow'
+    ]
+
     @TempDir
     File temporaryFolder
 

--- a/src/funcTest/groovy/me/champeau/jmh/JmhWithShadowPluginSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/jmh/JmhWithShadowPluginSpec.groovy
@@ -22,10 +22,10 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 @Unroll
 class JmhWithShadowPluginSpec extends AbstractFuncSpec {
 
-    def "Run #language benchmarks that are packaged with Shadow plugin (#gradleVersion)"() {
+    def "Run #language benchmarks that are packaged with Shadow plugin (#gradleVersion #language #shadowPlugin)"() {
 
         given:
-        usingSample("${language.toLowerCase()}-shadow-project")
+        usingSample("${language.toLowerCase()}-${TESTED_SHADOW_PLUGIN_FOLDERS[shadowPlugin]}-project")
         usingGradleVersion(gradleVersion)
         withoutConfigurationCache('shadow plugin unsupported')
 
@@ -37,9 +37,10 @@ class JmhWithShadowPluginSpec extends AbstractFuncSpec {
         benchmarksCsv.text.contains(language + 'Benchmark.sqrtBenchmark')
 
         where:
-        [language, gradleVersion] << [
+        [language, gradleVersion, shadowPlugin] << [
                 ['Java', 'Scala'],
-                TESTED_GRADLE_VERSIONS
+                TESTED_GRADLE_VERSIONS,
+                TESTED_SHADOW_PLUGINS
         ].combinations()
     }
 }

--- a/src/funcTest/groovy/me/champeau/jmh/ProjectWithDuplicateClassesSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/jmh/ProjectWithDuplicateClassesSpec.groovy
@@ -58,7 +58,7 @@ class ProjectWithDuplicateClassesSpec extends AbstractFuncSpec {
         gradleVersion << TESTED_GRADLE_VERSIONS
     }
 
-    def "Fail the build while executing jmhJar task when Shadow plugin applied (#gradleVersion)"() {
+    def "Fail the build while executing jmhJar task when Shadow plugin applied (#gradleVersion #shadowPlugin)"() {
 
         given:
         usingGradleVersion(gradleVersion)
@@ -68,7 +68,7 @@ class ProjectWithDuplicateClassesSpec extends AbstractFuncSpec {
         buildFile << """
             plugins {
                 id 'java'
-                id 'com.github.johnrengelman.shadow'
+                id '$shadowPlugin'
                 id 'me.champeau.jmh'
             }
 
@@ -88,7 +88,10 @@ class ProjectWithDuplicateClassesSpec extends AbstractFuncSpec {
         result.task(":jmhJar").outcome == FAILED
 
         where:
-        gradleVersion << TESTED_GRADLE_VERSIONS
+        [shadowPlugin, gradleVersion] << [
+                TESTED_SHADOW_PLUGINS,
+                TESTED_GRADLE_VERSIONS
+        ].combinations()
     }
 
     def "Show warning for duplicate classes when DuplicatesStrategy.WARN is used (#gradleVersion)"() {
@@ -123,7 +126,7 @@ class ProjectWithDuplicateClassesSpec extends AbstractFuncSpec {
         gradleVersion << TESTED_GRADLE_VERSIONS
     }
 
-    def "Show warning for duplicate classes when DuplicatesStrategy.WARN is used and Shadow plugin applied (#gradleVersion)"() {
+    def "Show warning for duplicate classes when DuplicatesStrategy.WARN is used and Shadow plugin applied (#gradleVersion #shadowPlugin)"() {
 
         given:
         usingGradleVersion(gradleVersion)
@@ -133,7 +136,7 @@ class ProjectWithDuplicateClassesSpec extends AbstractFuncSpec {
         buildFile << """
             plugins {
                 id 'java'
-                id 'com.github.johnrengelman.shadow'
+                id '$shadowPlugin'
                 id 'me.champeau.jmh'
             }
 
@@ -154,6 +157,9 @@ class ProjectWithDuplicateClassesSpec extends AbstractFuncSpec {
         result.output.contains('"me/champeau/jmh/Helper.class"')
 
         where:
-        gradleVersion << TESTED_GRADLE_VERSIONS
+        [shadowPlugin, gradleVersion] << [
+                TESTED_SHADOW_PLUGINS,
+                TESTED_GRADLE_VERSIONS
+        ].combinations()
     }
 }

--- a/src/funcTest/groovy/me/champeau/jmh/ProjectWithDuplicateDependenciesSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/jmh/ProjectWithDuplicateDependenciesSpec.groovy
@@ -50,7 +50,7 @@ class ProjectWithDuplicateDependenciesSpec extends AbstractFuncSpec {
         gradleVersion << TESTED_GRADLE_VERSIONS
     }
 
-    def "Run project with duplicate dependencies with Shadow applied (#gradleVersion)"() {
+    def "Run project with duplicate dependencies with Shadow applied (#gradleVersion #shadowPlugin)"() {
 
         given:
         usingGradleVersion(gradleVersion)
@@ -60,7 +60,7 @@ class ProjectWithDuplicateDependenciesSpec extends AbstractFuncSpec {
         createBuildFile("""
             plugins {
                 id 'java'
-                id 'com.github.johnrengelman.shadow'
+                id '$shadowPlugin'
                 id 'me.champeau.jmh'
             }
         """)
@@ -73,7 +73,10 @@ class ProjectWithDuplicateDependenciesSpec extends AbstractFuncSpec {
         benchmarksCsv.text.contains('JavaBenchmark.sqrtBenchmark')
 
         where:
-        gradleVersion << TESTED_GRADLE_VERSIONS
+        [shadowPlugin, gradleVersion] << [
+                TESTED_SHADOW_PLUGINS,
+                TESTED_GRADLE_VERSIONS
+        ].combinations()
     }
 
     void createBuildFile(String plugins) {

--- a/src/funcTest/resources/java-forked-shadow-project/build.gradle
+++ b/src/funcTest/resources/java-forked-shadow-project/build.gradle
@@ -15,7 +15,7 @@
  */
 plugins {
     id 'java'
-	id 'io.github.goooler.shadow'
+    id 'io.github.goooler.shadow'
     id 'me.champeau.jmh'
 }
 

--- a/src/funcTest/resources/java-forked-shadow-project/build.gradle
+++ b/src/funcTest/resources/java-forked-shadow-project/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+    id 'java'
+	id 'io.github.goooler.shadow'
+    id 'me.champeau.jmh'
+}
+
+repositories {
+    mavenCentral()
+}
+
+jmh {
+    resultFormat = 'csv'
+    resultsFile = file('build/reports/benchmarks.csv')
+}

--- a/src/funcTest/resources/java-forked-shadow-project/settings.gradle
+++ b/src/funcTest/resources/java-forked-shadow-project/settings.gradle
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2014-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+rootProject.name = "java-forked-shadow-project"

--- a/src/funcTest/resources/java-forked-shadow-project/src/jmh/java/me/champeau/gradle/jmh/mixlang/JavaBenchmark.java
+++ b/src/funcTest/resources/java-forked-shadow-project/src/jmh/java/me/champeau/gradle/jmh/mixlang/JavaBenchmark.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.jmh.mixlang;
+
+import org.openjdk.jmh.annotations.*;
+
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 0)
+@Measurement(iterations = 1)
+public class JavaBenchmark {
+    private double value;
+
+    @Setup
+    public void setUp() {
+        value = 3.0;
+    }
+
+    @Benchmark
+    public double sqrtBenchmark(){
+        return Math.sqrt(value);
+    }
+}

--- a/src/funcTest/resources/scala-forked-shadow-project/build.gradle
+++ b/src/funcTest/resources/scala-forked-shadow-project/build.gradle
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+    id 'scala'
+    id 'io.github.goooler.shadow'
+    id 'me.champeau.jmh'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.scala-lang:scala-library:2.13.11'
+}
+
+jmh {
+    resultFormat = 'csv'
+    resultsFile = file('build/reports/benchmarks.csv')
+}

--- a/src/funcTest/resources/scala-forked-shadow-project/settings.gradle
+++ b/src/funcTest/resources/scala-forked-shadow-project/settings.gradle
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2014-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+rootProject.name = "scala-forked-shadow-project"

--- a/src/funcTest/resources/scala-forked-shadow-project/src/jmh/scala/me/champeau/gradle/jmh/mixlang/ScalaBenchmark.scala
+++ b/src/funcTest/resources/scala-forked-shadow-project/src/jmh/scala/me/champeau/gradle/jmh/mixlang/ScalaBenchmark.scala
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2014-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.jmh.mixlang
+
+import org.openjdk.jmh.annotations._
+
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 0)
+@Measurement(iterations = 1)
+class ScalaBenchmark {
+  var value: Double = 0
+
+  @Setup
+  def setUp(): Unit = {
+    value = 3.0
+  }
+
+  @Benchmark
+  def sqrtBenchmark(): Double = {
+    return Math.sqrt(value)
+  }
+
+}

--- a/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
@@ -64,7 +64,7 @@ class JMHPlugin implements Plugin<Project> {
         dependencyHandler.addProvider(JMH_NAME, project.providers.provider { "${JMH_CORE_DEPENDENCY}${extension.jmhVersion.get()}" }) {}
         dependencyHandler.addProvider(JMH_NAME, project.providers.provider { "${JMH_GENERATOR_DEPENDENCY}${extension.jmhVersion.get()}" }) {}
 
-        def hasShadow = project.plugins.findPlugin('com.github.johnrengelman.shadow') != null
+        def hasShadow = project.plugins.findPlugin('com.github.johnrengelman.shadow') != null || project.plugins.findPlugin('io.github.goooler.shadow') != null
 
         createJmhSourceSet(project)
         final Configuration runtimeConfiguration = configureJmhRuntimeClasspathConfiguration(project, extension)

--- a/src/test/groovy/me/champeau/jmh/JMHPluginTest.groovy
+++ b/src/test/groovy/me/champeau/jmh/JMHPluginTest.groovy
@@ -102,21 +102,27 @@ class JMHPluginTest extends Specification {
         }
     }
 
-    def "plugin is applied together with shadow"() {
+    def "plugin is applied together with shadow plugin (#shadowPlugin)"() {
         when:
         Project project = ProjectBuilder.builder().build()
         project.repositories {
             mavenCentral()
         }
         project.apply plugin: 'java'
-        project.apply plugin: 'com.github.johnrengelman.shadow'
+        project.apply plugin: shadowPlugin
         project.apply plugin: 'me.champeau.jmh'
 
         then:
         def task = project.tasks.findByName('jmhJar')
         task instanceof ShadowJar
+
+        where:
+        shadowPlugin << [
+                'com.github.johnrengelman.shadow',
+                'io.github.goooler.shadow'
+        ]
     }
-    
+
     void "default duplicates strategy is to include"() {
         when:
         Project project = ProjectBuilder.builder().build()


### PR DESCRIPTION
The shadow-plugin (ID `com.github.johnrengelman.shadow`) is currently rather unmaintained (last change in March/April 2023 as of January 2024) and already has a bunch of issues, especially with newer Gradle versions (8.2+) and when the included classes are built for Java 21 or newer (class file version 65+). This is problematic when using Java 21 directly or including a recent version of jackson-core, which is a multi-release jar that contains Java 21 classes.

There is a fork of the shadow plugin (ID `io.github.goooler.shadow`) that works against newer Gradle versions and Java 21. That one however is not recognized by the jmh plugin, which only check against the "original" plugin ID.

This change adds support for the forked plugin, one line change in the production code, other changes are readme and tests.