### PR TITLE
Use Property.set() for archiveClassifier in createStandardJmhJar

### DIFF
--- a/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
+++ b/src/main/groovy/me/champeau/jmh/JMHPlugin.groovy
@@ -300,7 +300,7 @@ class JMHPlugin implements Plugin<Project> {
                 attributes 'Main-Class': 'org.openjdk.jmh.Main'
             }
 
-            it.archiveClassifier = JMH_NAME
+            it.archiveClassifier.set(JMH_NAME)
             it.zip64 = extension.zip64.get()
         }
     }


### PR DESCRIPTION
## Summary

- Use `archiveClassifier.set(JMH_NAME)` instead of `archiveClassifier = JMH_NAME` in `createStandardJmhJar`, consistent with `createShadowJmhJar` (line 227) which already uses `.set()`

`archiveClassifier` is a `Property<String>` on `AbstractArchiveTask`. The assignment syntax calls Gradle's generated `setArchiveClassifier(Object)` setter, while `.set()` uses the Property API directly. Both are functionally equivalent, but `.set()` is the preferred approach for `Property<T>` types.

## Test plan

- [x] Unit tests pass (`JMHPluginTest` — 10 tests)
- [x] Functional tests pass (16 tests across Gradle 7.0, 8.0, 8.14.3 with Java, Groovy, Kotlin, Scala projects, Shadow plugin integration, multi-project builds)