### PR TITLE
Bump default JMH version from 1.36 to 1.37

### DIFF
--- a/src/main/java/me/champeau/jmh/DefaultsConfigurer.java
+++ b/src/main/java/me/champeau/jmh/DefaultsConfigurer.java
@@ -21,7 +21,7 @@ import org.gradle.api.file.DuplicatesStrategy;
 
 class DefaultsConfigurer {
     public static void configureDefaults(JmhParameters params, Project project) {
-        params.getJmhVersion().convention("1.36");
+        params.getJmhVersion().convention("1.37");
         params.getIncludeTests().convention(true);
         params.getZip64().convention(false);
         params.getDuplicateClassesStrategy().convention(DuplicatesStrategy.INCLUDE);


### PR DESCRIPTION
# Description

This updates the plugin's default JMH version from `1.36` to `1.37`.

## Changes

- `src/main/java/me/champeau/jmh/DefaultsConfigurer.java`: changed the `jmhVersion` convention default from `1.36` to `1.37`.

The plugin's own build dependencies (`build.gradle.kts`) and the documented default in `README.adoc` already reference `1.37`, so this change brings the convention default in line with them.

## Impact

Projects applying the plugin without explicitly setting `jmhVersion` will now resolve JMH `1.37` by default. Projects that pin their own `jmhVersion` are unaffected.
