### PR TITLE
Track JMH version in the Gradle version catalog

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -148,7 +148,7 @@ jmh {
    listProfilersDetails = true // List the available profilers with their descriptions and exit.
    listResultFormats = true // List the available result formats and exit.
 
-  jmhOptions = ['-o', 'result.txt', '-rf', 'json'] // Arbitrary JMH command line options passed through to the JMH runner (null/empty elements are ignored). Useful for options not natively modeled by the plugin, or to combine several options at once. Avoid duplicating flags already modeled by the plugin (e.g. listBenchmarks, listProfilers, verbosity).
+   jmhOptions = ['-o', 'result.txt', '-rf', 'json'] // Arbitrary JMH command line options passed through to the JMH runner (null/empty elements are ignored). Useful for options not natively modeled by the plugin, or to combine several options at once. Avoid duplicating flags already modeled by the plugin (e.g. listBenchmarks, listProfilers, verbosity).
 
    zip64 = true // Use ZIP64 format for bigger archives
    jmhVersion = '{jmh-version}' // Specifies JMH version

--- a/README.adoc
+++ b/README.adoc
@@ -148,7 +148,7 @@ jmh {
    listProfilersDetails = true // List the available profilers with their descriptions and exit.
    listResultFormats = true // List the available result formats and exit.
 
-   jmhOptions = ['-o', 'result.txt', '-rf', 'json'] // Arbitrary JMH command line options passed through to the JMH runner (null/empty elements are ignored). Useful for options not natively modeled by the plugin, or to combine several options at once. Avoid duplicating flags already modeled by the plugin (e.g. listBenchmarks, listProfilers, verbosity).
+  jmhOptions = ['-o', 'result.txt', '-rf', 'json'] // Arbitrary JMH command line options passed through to the JMH runner (null/empty elements are ignored). Useful for options not natively modeled by the plugin, or to combine several options at once. Avoid duplicating flags already modeled by the plugin (e.g. listBenchmarks, listProfilers, verbosity).
 
    zip64 = true // Use ZIP64 format for bigger archives
    jmhVersion = '{jmh-version}' // Specifies JMH version

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,9 @@ buildScanRecipes {
 buildConfig {
     packageName = "me.champeau.jmh"
     useJavaOutput()
-    buildConfigField("JMH_VERSION", libs.versions.jmh.get())
+    sourceSets.named("main") {
+        buildConfigField("JMH_VERSION", libs.versions.jmh)
+    }
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     pluginsUnderTest(libs.foojayResolver)
     pluginsUnderTest(libs.shadow.gradlePlugin)
 
+    testImplementation(libs.jmh.core)
     testImplementation(libs.jmh.generatorBytecode)
     testImplementation(libs.apache.commonsIo)
     testImplementation(libs.shadow.gradlePlugin)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,10 +33,8 @@ buildScanRecipes {
 
 buildConfig {
     packageName = "me.champeau.jmh"
-
-    sourceSets.named("main") {
-        buildConfigField("JMH_VERSION", libs.versions.jmh.get())
-    }
+    useJavaOutput()
+    buildConfigField("JMH_VERSION", libs.versions.jmh.get())
 }
 
 dependencies {
@@ -51,7 +49,6 @@ dependencies {
     pluginsUnderTest(libs.foojayResolver)
     pluginsUnderTest(libs.shadow.gradlePlugin)
 
-    testImplementation(libs.jmh.core)
     testImplementation(libs.jmh.generatorBytecode)
     testImplementation(libs.apache.commonsIo)
     testImplementation(libs.shadow.gradlePlugin)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
     alias(libs.plugins.apache.rat)
     alias(libs.plugins.versioning)
     alias(libs.plugins.coveralls)
+    id("com.github.gmazzo.buildconfig") version "6.0.10"
     id("me.champeau.convention-test")
     id("me.champeau.convention-funcTest")
     id("me.champeau.plugin-configuration")
@@ -28,6 +29,14 @@ plugins {
 buildScanRecipes {
     recipes("git-status", "travis-ci")
     recipe(mapOf("baseUrl" to "https://github.com/melix/jmh-gradle-plugin/tree"), "git-commit")
+}
+
+buildConfig {
+    packageName = "me.champeau.jmh"
+
+    sourceSets.named("main") {
+        buildConfigField("JMH_VERSION", libs.versions.jmh.get())
+    }
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
     alias(libs.plugins.apache.rat)
     alias(libs.plugins.versioning)
     alias(libs.plugins.coveralls)
-    id("com.github.gmazzo.buildconfig") version "6.0.10"
+    alias(libs.plugins.buildconfig)
     id("me.champeau.convention-test")
     id("me.champeau.convention-funcTest")
     id("me.champeau.plugin-configuration")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,3 +16,7 @@ apache-rat = "org.nosphere.apache.rat:0.8.1"
 buildScanRecipes = "me.champeau.buildscan-recipes:0.2.3"
 coveralls = "com.github.kt3k.coveralls:2.12.2"
 versioning = "net.nemerosa.versioning:3.1.0"
+
+[libraries]
+jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
+jmh-generator-bytecode = { module = "org.openjdk.jmh:jmh-generator-bytecode", version.ref = "jmh" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,9 +14,6 @@ spock-core = "org.spockframework:spock-core:2.3-groovy-4.0"
 [plugins]
 apache-rat = "org.nosphere.apache.rat:0.8.1"
 buildScanRecipes = "me.champeau.buildscan-recipes:0.2.3"
+buildconfig = "com.github.gmazzo.buildconfig:6.0.10"
 coveralls = "com.github.kt3k.coveralls:2.12.2"
 versioning = "net.nemerosa.versioning:3.1.0"
-
-[libraries]
-jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
-jmh-generator-bytecode = { module = "org.openjdk.jmh:jmh-generator-bytecode", version.ref = "jmh" }

--- a/src/main/java/me/champeau/jmh/DefaultsConfigurer.java
+++ b/src/main/java/me/champeau/jmh/DefaultsConfigurer.java
@@ -21,7 +21,7 @@ import org.gradle.api.file.DuplicatesStrategy;
 
 class DefaultsConfigurer {
     public static void configureDefaults(JmhParameters params, Project project) {
-        params.getJmhVersion().convention("1.37");
+        params.getJmhVersion().convention(BuildConfig.JMH_VERSION);
         params.getIncludeTests().convention(true);
         params.getZip64().convention(false);
         params.getDuplicateClassesStrategy().convention(DuplicatesStrategy.INCLUDE);


### PR DESCRIPTION
Following up on the discussion in #291, this moves the JMH version out of a hardcoded string and into the Gradle version catalog so that Dependabot can keep it up to date automatically.

The JMH version now has a single definition in `gradle/libs.versions.toml` (`jmh = "1.37"`), and the dependency coordinates live in `[libraries]` (`jmh-core`, `jmh-generator-bytecode`) so the strings themselves are tracked too. Both feed the plugin's own build dependency and the default version applied to user projects via a Java-generated `BuildConfig.JMH_VERSION` in `DefaultsConfigurer`.