### PR TITLE
Catalog build dependencies and plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,10 +16,10 @@
 
 plugins {
     jacoco
-    id("me.champeau.buildscan-recipes") version "0.2.3"
-    id("org.nosphere.apache.rat") version "0.8.1"
-    id("net.nemerosa.versioning") version "3.1.0"
-    id("com.github.kt3k.coveralls") version "2.12.2"
+    alias(libs.plugins.buildScanRecipes)
+    alias(libs.plugins.apache.rat)
+    alias(libs.plugins.versioning)
+    alias(libs.plugins.coveralls)
     id("me.champeau.convention-test")
     id("me.champeau.convention-funcTest")
     id("me.champeau.plugin-configuration")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,23 +31,22 @@ buildScanRecipes {
 }
 
 dependencies {
-    val jmhVersion = "1.37"
-    implementation("org.openjdk.jmh:jmh-core:$jmhVersion")
+    implementation(libs.jmh.core)
 
-    testImplementation("org.spockframework:spock-core:2.3-groovy-4.0") {
+    testImplementation(libs.spock.core) {
         exclude(mapOf("group" to "org.apache.groovy"))
     }
     testImplementation(localGroovy())
     testImplementation(gradleTestKit())
 
-    pluginsUnderTest("org.gradle.toolchains:foojay-resolver:1.0.0")
-    pluginsUnderTest("com.gradleup.shadow:shadow-gradle-plugin:8.3.0")
+    pluginsUnderTest(libs.foojayResolver)
+    pluginsUnderTest(libs.shadow.gradlePlugin)
 
-    testImplementation("org.openjdk.jmh:jmh-core:$jmhVersion")
-    testImplementation("org.openjdk.jmh:jmh-generator-bytecode:$jmhVersion")
-    testImplementation("commons-io:commons-io:2.21.0")
-    testImplementation("com.gradleup.shadow:shadow-gradle-plugin:8.3.0")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation(libs.jmh.core)
+    testImplementation(libs.jmh.generatorBytecode)
+    testImplementation(libs.apache.commonsIo)
+    testImplementation(libs.shadow.gradlePlugin)
+    testRuntimeOnly(libs.junit.platformLauncher)
 }
 
 java {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,12 @@
+[versions]
+jmh = "1.37"
+shadow = "8.3.0"
+
+[libraries]
+apache-commonsIo = "commons-io:commons-io:2.21.0"
+foojayResolver = "org.gradle.toolchains:foojay-resolver:1.0.0"
+jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
+jmh-generatorBytecode = { module = "org.openjdk.jmh:jmh-generator-bytecode", version.ref = "jmh" }
+junit-platformLauncher = { module = "org.junit.platform:junit-platform-launcher" }
+shadow-gradlePlugin = { module = "com.gradleup.shadow:shadow-gradle-plugin", version.ref = "shadow" }
+spock-core = "org.spockframework:spock-core:2.3-groovy-4.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,3 +10,9 @@ jmh-generatorBytecode = { module = "org.openjdk.jmh:jmh-generator-bytecode", ver
 junit-platformLauncher = { module = "org.junit.platform:junit-platform-launcher" }
 shadow-gradlePlugin = { module = "com.gradleup.shadow:shadow-gradle-plugin", version.ref = "shadow" }
 spock-core = "org.spockframework:spock-core:2.3-groovy-4.0"
+
+[plugins]
+apache-rat = "org.nosphere.apache.rat:0.8.1"
+buildScanRecipes = "me.champeau.buildscan-recipes:0.2.3"
+coveralls = "com.github.kt3k.coveralls:2.12.2"
+versioning = "net.nemerosa.versioning:3.1.0"


### PR DESCRIPTION
## Summary

- add a Gradle version catalog for build dependencies and plugins
- replace external dependency coordinates with type-safe catalog accessors
- replace versioned external plugin declarations with catalog aliases

## Motivation

Centralizing dependency and plugin versions makes upgrades easier and keeps the root build script focused on build configuration.

Gradle-provided dependencies, the built-in JaCoCo plugin, and local convention plugins remain declared directly because they do not use external version coordinates.

## Testing

- `./gradlew help`
- `git diff --check`
