### PR TITLE
Add `--jmhArgs` task option to pass and override JMH options at invocation time

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Unreleased
     * Bump default JMH version from 1.36 to 1.37 (#291)
     * Add jmhOptions passthrough (List<String>) to pass arbitrary JMH command line options verbatim to the JMH runner (#46)
     * Add JMH list flags (listBenchmarks, listProfilers, listProfilersDetails, listResultFormats) to expose more JMH command line options (#46)
+    * Add --jmhArgs task option as a zero-config shorthand for jmhOptions, allowing raw JMH options to be passed at invocation time (e.g. `./gradlew jmh --jmhArgs="-t 4 -wi 5 -i 10"`) without editing build.gradle. --jmhArgs takes precedence over a jmhOptions set in build.gradle (#54)
 Version 0.7.3
 -------------
     * Do not access 'project.zipTree' in mapping closure

--- a/README.adoc
+++ b/README.adoc
@@ -148,7 +148,8 @@ jmh {
    listProfilersDetails = true // List the available profilers with their descriptions and exit.
    listResultFormats = true // List the available result formats and exit.
 
-  jmhOptions = ['-o', 'result.txt', '-rf', 'json'] // Arbitrary JMH command line options passed through to the JMH runner (null/empty elements are ignored). Useful for options not natively modeled by the plugin, or to combine several options at once. Avoid duplicating flags already modeled by the plugin (e.g. listBenchmarks, listProfilers, verbosity).
+   // See "Passing JMH options at invocation time (jmhArgs)" below for the --jmhArgs option.
+   jmhOptions = ['-o', 'result.txt', '-rf', 'json'] // Arbitrary JMH command line options passed through to the JMH runner (null/empty elements are ignored). Useful for options not natively modeled by the plugin, or to combine several options at once. Avoid duplicating flags already modeled by the plugin (e.g. listBenchmarks, listProfilers, verbosity).
 
    zip64 = true // Use ZIP64 format for bigger archives
    jmhVersion = '{jmh-version}' // Specifies JMH version
@@ -156,6 +157,29 @@ jmh {
    duplicateClassesStrategy = DuplicatesStrategy.FAIL // Strategy to apply when encountring duplicate classes during creation of the fat jar (i.e. while executing jmhJar task)
 }
 ----
+
+=== Passing JMH options at invocation time (jmhArgs)
+
+As a convenience, any JMH command line option can be passed directly at invocation time
+via the `jmhArgs` task option, without editing `build.gradle`:
+
+[source,bash]
+----
+./gradlew jmh --jmhArgs="-t 4 -wi 5 -i 10"
+----
+
+The `--jmhArgs` value is tokenized on whitespace and fed into the same `jmhOptions`
+pass-through described above, so it reaches the JMH runner verbatim. This is handy for
+one-off runs (e.g. quickly changing thread count or warmup iterations) where you do
+not want to modify the build script.
+
+An explicit `--jmhArgs` passed on the command line takes precedence over `jmhOptions`
+set in the `jmh { }` block; if both are present, only the `--jmhArgs` value is used.
+When `--jmhArgs` is omitted, the build script's `jmhOptions` apply.
+
+NOTE: `--jmhArgs` is split on whitespace, so options whose _values_ contain spaces
+(for example `-p "a=1 b=2"`) will not be parsed correctly. For those, use `jmhOptions`
+in `build.gradle` instead.
 
 == JMH Options Mapping
 
@@ -194,10 +218,10 @@ The following table describes the mappings between JMH's command line options an
 | -wi <int>                | warmupIterations
 | -wm <mode>               | warmupMode
 | -wmb <regexp+>           | warmupBenchmarks
-| -l                      | listBenchmarks
-| -lp                     | listProfilers
-| -lprof                  | listProfilersDetails
-| -lrf                    | listResultFormats
+| -l                       | listBenchmarks
+| -lp                      | listProfilers
+| -lprof                   | listProfilersDetails
+| -lrf                     | listResultFormats
 | (raw JMH options)        | jmhOptions
 |===
 

--- a/README.adoc
+++ b/README.adoc
@@ -173,9 +173,7 @@ pass-through described above, so it reaches the JMH runner verbatim. This is han
 one-off runs (e.g. quickly changing thread count or warmup iterations) where you do
 not want to modify the build script.
 
-An explicit `--jmhArgs` passed on the command line takes precedence over `jmhOptions`
-set in the `jmh { }` block; if both are present, only the `--jmhArgs` value is used.
-When `--jmhArgs` is omitted, the build script's `jmhOptions` apply.
+An explicit `--jmhArgs` passed on the command line takes precedence over modeled options and any overlapping flags from `jmhOptions` set in the `jmh { }` block; when the same flag is present in both places, the `--jmhArgs` value wins. Flags not mentioned in `--jmhArgs` are left untouched. When `--jmhArgs` is omitted, the build script's `jmhOptions` apply.
 
 NOTE: `--jmhArgs` is split on whitespace, so options whose _values_ contain spaces
 (for example `-p "a=1 b=2"`) will not be parsed correctly. For those, use `jmhOptions`

--- a/src/funcTest/groovy/me/champeau/jmh/ParameterSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/jmh/ParameterSpec.groovy
@@ -58,7 +58,7 @@ class ParameterSpec extends AbstractFuncSpec {
 
     }
 
-    def "--jmhArgs project property is tokenized into JMH arguments"() {
+    def "--jmhArgs task option is tokenized into JMH arguments"() {
         given:
         usingSample("java-project")
 

--- a/src/funcTest/groovy/me/champeau/jmh/ParameterSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/jmh/ParameterSpec.groovy
@@ -130,13 +130,13 @@ class ParameterSpec extends AbstractFuncSpec {
         usingSample("java-project")
 
         when:
-        // --jmhArgs contains a benchmark name pattern as a positional (non-flag) token
-        def result = build("jmh", "--jmhArgs=MyBenchmark -t 4", "--info")
+        // --jmhArgs contains a real benchmark class pattern (non-flag token) + JMH flags
+        def result = build("jmh", "--jmhArgs=JavaBenchmark -t 4", "--info")
 
         then:
         result.output.contains('Running JMH with arguments:')
         // non-flag token is appended, not dropped
-        result.output.contains('MyBenchmark')
+        result.output.contains('JavaBenchmark')
         // flag tokens are still processed normally
         result.output.contains('-t, 4')
     }

--- a/src/funcTest/groovy/me/champeau/jmh/ParameterSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/jmh/ParameterSpec.groovy
@@ -57,4 +57,71 @@ class ParameterSpec extends AbstractFuncSpec {
         result.output.contains("Configuration cache entry reused.")
 
     }
+
+    def "--jmhArgs project property is tokenized into JMH arguments"() {
+        given:
+        usingSample("java-project")
+
+        when:
+        def result = build("jmh", "--jmhArgs=-t 4 -wi 5 -i 10", "--info")
+
+        then:
+        result.output.contains('Running JMH with arguments:')
+        // the --jmhArgs string is split into individual JMH tokens
+        result.output.contains('-t')
+        result.output.contains('4')
+        result.output.contains('-wi')
+        result.output.contains('5')
+        result.output.contains('-i')
+        result.output.contains('10')
+    }
+
+    def "--jmhArgs adds non-overlapping flags to jmhOptions"() {
+        given:
+        usingSample("java-project")
+
+        when:
+        // jmhOptions in build.gradle is ['-tu', 'ms']; --jmhArgs uses non-overlapping flags
+        def result = build("jmh", "--jmhArgs=-f 1 -wi 5", "--info")
+
+        then:
+        result.output.contains('Running JMH with arguments:')
+        // --jmhArgs flags are present
+        result.output.contains('-wi, 5')
+        result.output.contains('-f, 1')
+        // buildscript's jmhOptions also survive (no overlap, so no conflict)
+        result.output.contains('-tu, ms')
+    }
+
+    def "--jmhArgs replaces matching flags from jmhOptions"() {
+        given:
+        usingSample("java-project")
+
+        when:
+        // jmhOptions in build.gradle is ['-tu', 'ms']; --jmhArgs also sets -tu ns
+        def result = build("jmh", "--jmhArgs=-tu ns -f 1", "--info")
+
+        then:
+        result.output.contains('Running JMH with arguments:')
+        // --jmhArgs -tu ns replaces buildscript -tu ms
+        result.output.contains('-tu, ns')
+        !result.output.contains('-tu, ms')
+        // new flags from --jmhArgs are appended
+        result.output.contains('-f, 1')
+    }
+
+    def "--jmhArgs overrides modeled property from build.gradle"() {
+        given:
+        usingSample("java-project")
+
+        when:
+        // benchmarkMode in build.gradle is ['thrpt','ss'] → args contain -bm thrpt,ss
+        def result = build("jmh", "--jmhArgs=-bm ss", "--info")
+
+        then:
+        result.output.contains('Running JMH with arguments:')
+        // --jmhArgs replaces the modeled -bm value
+        result.output.contains('-bm, ss')
+        !result.output.contains('-bm, thrpt,ss')
+    }
 }

--- a/src/funcTest/groovy/me/champeau/jmh/ParameterSpec.groovy
+++ b/src/funcTest/groovy/me/champeau/jmh/ParameterSpec.groovy
@@ -124,4 +124,20 @@ class ParameterSpec extends AbstractFuncSpec {
         result.output.contains('-bm, ss')
         !result.output.contains('-bm, thrpt,ss')
     }
+
+    def "--jmhArgs appends non-flag tokens as positional JMH args"() {
+        given:
+        usingSample("java-project")
+
+        when:
+        // --jmhArgs contains a benchmark name pattern as a positional (non-flag) token
+        def result = build("jmh", "--jmhArgs=MyBenchmark -t 4", "--info")
+
+        then:
+        result.output.contains('Running JMH with arguments:')
+        // non-flag token is appended, not dropped
+        result.output.contains('MyBenchmark')
+        // flag tokens are still processed normally
+        result.output.contains('-t, 4')
+    }
 }

--- a/src/funcTest/resources/java-project/build.gradle
+++ b/src/funcTest/resources/java-project/build.gradle
@@ -28,4 +28,5 @@ jmh {
     resultsFile = file('build/reports/benchmarks.csv')
     benchmarkParameters = [a: ['a']]
     failOnError = true
+    jmhOptions = ['-tu', 'ms']
 }

--- a/src/main/java/me/champeau/jmh/JMHTask.java
+++ b/src/main/java/me/champeau/jmh/JMHTask.java
@@ -20,18 +20,23 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
 import org.gradle.work.DisableCachingByDefault;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.process.ExecOperations;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * The JMH task is responsible for launching a JMH benchmark.
@@ -39,6 +44,8 @@ import java.util.List;
 @DisableCachingByDefault(because = "Benchmark results depend on the runtime environment and should not be cached")
 public abstract class JMHTask extends DefaultTask implements JmhParameters {
     private final static String JAVA_IO_TMPDIR = "java.io.tmpdir";
+
+    private final Property<String> jmhArgs = getObjects().property(String.class);
 
     @Inject
     public abstract ExecOperations getExecOperations();
@@ -55,7 +62,6 @@ public abstract class JMHTask extends DefaultTask implements JmhParameters {
     @Classpath
     public abstract RegularFileProperty getJarArchive();
 
-
     @OutputFile
     @Optional
     public abstract RegularFileProperty getHumanOutputFile();
@@ -63,15 +69,36 @@ public abstract class JMHTask extends DefaultTask implements JmhParameters {
     @OutputFile
     public abstract RegularFileProperty getResultsFile();
 
+    /**
+     * Allows passing arbitrary JMH command line options at invocation time, e.g.
+     * <pre>
+     *     ./gradlew jmh --jmhArgs="-t 4 -wi 5 -i 10"
+     * </pre>
+     * The value is tokenized on whitespace and merged into the JMH arguments,
+     * taking precedence over any {@code jmhOptions} configured in the build script.
+     *
+     * @param value the raw JMH options, space separated
+     */
+    @Option(option = "jmhArgs", description = "Arbitrary JMH command line options to pass to the JMH runner, space separated (takes precedence over jmhOptions).")
+    public void setJmhArgs(String value) {
+        jmhArgs.set(value);
+    }
+
     @TaskAction
     public void callJmh() {
-        List<String> jmhArgs = new ArrayList<>();
-        ParameterConverter.collectParameters(this, jmhArgs);
-        getLogger().info("Running JMH with arguments: " + jmhArgs);
+        List<String> args = new ArrayList<>();
+        ParameterConverter.collectParameters(this, args);
+        if (jmhArgs.isPresent()) {
+            String raw = jmhArgs.get();
+            if (!raw.trim().isEmpty()) {
+                applyCliArgs(args, raw.trim().split("\\s+"));
+            }
+        }
+        getLogger().info("Running JMH with arguments: " + args);
         getExecOperations().javaexec(spec -> {
             spec.setClasspath(computeClasspath());
             spec.getMainClass().set("org.openjdk.jmh.Main");
-            spec.args(jmhArgs);
+            spec.args(args);
             spec.systemProperty(JAVA_IO_TMPDIR, getTemporaryDir().getAbsolutePath());
             spec.environment(getEnvironment().get());
             Provider<JavaLauncher> javaLauncher = getJavaLauncher();
@@ -79,6 +106,47 @@ public abstract class JMHTask extends DefaultTask implements JmhParameters {
                 spec.executable(javaLauncher.get().getExecutablePath().getAsFile());
             }
         });
+    }
+
+    /**
+     * Applies CLI tokens to the args list: matching flags get their values replaced,
+     * presence-only flags that appear in CLI are kept; new flags are appended.
+     */
+    private static void applyCliArgs(List<String> args, String[] tokens) {
+        // presence-only flags (no value)
+        Set<String> presenceFlags = new LinkedHashSet<>(Arrays.asList(
+                "-l", "-lp", "-lprof", "-lrf", "-h", "-hh"));
+
+        for (int i = 0; i < tokens.length; i++) {
+            String flag = tokens[i];
+            if (!flag.startsWith("-")) {
+                continue;
+            }
+
+            String value = null;
+            if (!presenceFlags.contains(flag)) {
+                boolean hasNextToken = i + 1 < tokens.length;
+                boolean nextIsValue = hasNextToken && !tokens[i + 1].startsWith("-");
+                if (nextIsValue) {
+                    value = tokens[++i];
+                }
+            }
+
+            // replace matching flag in existing args, or append
+            int idx = args.indexOf(flag);
+            if (idx >= 0) {
+                boolean hasBuildscriptValue = idx + 1 < args.size()
+                        && !args.get(idx + 1).startsWith("-");
+                if (value != null && hasBuildscriptValue) {
+                    args.set(idx + 1, value);
+                }
+            } else {
+                args.add(flag);
+                if (value != null) {
+                    args.add(value);
+                }
+            }
+        }
     }
 
     private FileCollection computeClasspath() {

--- a/src/main/java/me/champeau/jmh/JMHTask.java
+++ b/src/main/java/me/champeau/jmh/JMHTask.java
@@ -24,6 +24,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
@@ -44,8 +45,6 @@ import java.util.Set;
 @DisableCachingByDefault(because = "Benchmark results depend on the runtime environment and should not be cached")
 public abstract class JMHTask extends DefaultTask implements JmhParameters {
     private final static String JAVA_IO_TMPDIR = "java.io.tmpdir";
-
-    private final Property<String> jmhArgs = getObjects().property(String.class);
 
     @Inject
     public abstract ExecOperations getExecOperations();
@@ -74,22 +73,21 @@ public abstract class JMHTask extends DefaultTask implements JmhParameters {
      * <pre>
      *     ./gradlew jmh --jmhArgs="-t 4 -wi 5 -i 10"
      * </pre>
-     * The value is tokenized on whitespace and merged into the JMH arguments,
-     * taking precedence over any {@code jmhOptions} configured in the build script.
+     * The value is tokenized on whitespace and replaces matching flags from the build script.
      *
-     * @param value the raw JMH options, space separated
+     * @return the raw JMH options, space separated
      */
-    @Option(option = "jmhArgs", description = "Arbitrary JMH command line options to pass to the JMH runner, space separated (takes precedence over jmhOptions).")
-    public void setJmhArgs(String value) {
-        jmhArgs.set(value);
-    }
+    @Optional
+    @Input
+    @Option(option = "jmhArgs", description = "Arbitrary JMH command line options to pass to the JMH runner, space separated.")
+    public abstract Property<String> getJmhArgs();
 
     @TaskAction
     public void callJmh() {
         List<String> args = new ArrayList<>();
         ParameterConverter.collectParameters(this, args);
-        if (jmhArgs.isPresent()) {
-            String raw = jmhArgs.get();
+        if (getJmhArgs().isPresent()) {
+            String raw = getJmhArgs().get();
             if (!raw.trim().isEmpty()) {
                 applyCliArgs(args, raw.trim().split("\\s+"));
             }

--- a/src/main/java/me/champeau/jmh/JMHTask.java
+++ b/src/main/java/me/champeau/jmh/JMHTask.java
@@ -118,6 +118,7 @@ public abstract class JMHTask extends DefaultTask implements JmhParameters {
         for (int i = 0; i < tokens.length; i++) {
             String flag = tokens[i];
             if (!flag.startsWith("-")) {
+                args.add(flag);
                 continue;
             }
 

--- a/src/main/java/me/champeau/jmh/ParameterConverter.java
+++ b/src/main/java/me/champeau/jmh/ParameterConverter.java
@@ -22,6 +22,7 @@ import org.gradle.api.provider.Provider;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Collections;
 
 import static java.util.stream.Collectors.joining;
 
@@ -67,11 +68,8 @@ public class ParameterConverter {
     }
 
     private static void addRawOptions(List<String> into, ListProperty<String> options) {
-        if (!options.isPresent()) {
-            return;
-        }
-        for (String option : options.get()) {
-            if (option != null && !option.isEmpty()) {
+        for (String option : options.getOrElse(Collections.emptyList())) {
+            if (!option.isEmpty()) {
                 into.add(option);
             }
         }
@@ -127,7 +125,7 @@ public class ParameterConverter {
      * flag is emitted only when the boolean is explicitly true; false/absent emits nothing.
      */
     private static void addPresenceOption(List<String> options, Provider<Boolean> b, String option) {
-        if (b.isPresent() && Boolean.TRUE.equals(b.get())) {
+        if (b.isPresent() && b.get()) {
             options.add("-" + option);
         }
     }


### PR DESCRIPTION
## Summary

Adds a `--jmhArgs` Gradle task option that lets users pass arbitrary JMH command-line options at `gradle jmh` invocation time without editing `build.gradle`. It uses Gradle's built-in `@Option` so the option shows up in `--help` and benefits from Gradle's option parsing.

```bash
./gradlew jmh --jmhArgs="-t 4 -wi 5 -i 10"
```

## Precedence

When `--jmhArgs` contains a flag that also exists in the build script (`jmhOptions` or a modeled property like `benchmarkMode`), the CLI value replaces the build script value. Flags not mentioned in `--jmhArgs` are left untouched. When `--jmhArgs` is omitted, the build script applies as before — fully backward compatible.

Example: if `build.gradle` sets `benchmarkMode = ['thrpt', 'ss']` and `jmhOptions = ['-tu', 'ms']`, then `--jmhArgs="-bm ss -f 1"` produces args where `-bm ss` replaces `benchmarkMode`, `-tu ms` is preserved, and `-f 1` is appended.

Closes #54